### PR TITLE
Add NoDL conformance comparison and conform verb

### DIFF
--- a/.github/workflows/rosdoc2.yml
+++ b/.github/workflows/rosdoc2.yml
@@ -30,6 +30,7 @@ jobs:
         package:
           - ament_nodl
           - nodl_common_interfaces
+          - nodl_conformance
           - nodl_docgen
           - nodl_generator_cpp
           - nodl_observe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         uses: ros-tooling/action-ros-ci@v0.4
         with:
           package-name: >-
-            ament_nodl nodl nodl_observe nodl_schema ros2nodl test_ament_nodl
+            ament_nodl nodl nodl_conformance nodl_observe nodl_schema ros2nodl test_ament_nodl
             nodl_generator_cpp test_nodl_generator_cpp nodl_tutorial_basics
           target-ros2-distro: ${{ matrix.ros }}
       - uses: actions/upload-artifact@v4

--- a/nodl/doc/index.md
+++ b/nodl/doc/index.md
@@ -32,6 +32,8 @@ tutorials/index
 - **`nodl_common_interfaces`** — NoDL descriptions for standard ROS 2 node base classes (`rclcpp::Node`, `rclcpp_lifecycle::LifecycleNode`), registered in the ament index until upstream ships its own.
 - **`nodl_generator_cpp`** — C++ code generation from NoDL documents: generates an abstract base class with all endpoint wiring, delegating parameters to `generate_parameter_library`.
 - **`nodl_docgen`** — Tools to generate documentation from NoDL documents.
+- **`nodl_conformance`** — semantic comparison of two loaded NoDL documents.
+  `ros2nodl` provides runtime conformance checks for live nodes.
 
 Each package's own documentation is staged into this site from its `doc/` tree at build time
 (see {repo}`nodl/doc/package_docs.py`); the same sources build standalone under `rosdoc2` for docs.ros.org.
@@ -47,6 +49,7 @@ ament_nodl <_generated/packages/ament_nodl/overview>
 nodl_common_interfaces <_generated/packages/nodl_common_interfaces/overview>
 nodl_generator_cpp <_generated/packages/nodl_generator_cpp/overview>
 nodl_docgen <_generated/packages/nodl_docgen/overview>
+nodl_conformance <_generated/packages/nodl_conformance/overview>
 ```
 
 ## Source

--- a/nodl/doc/package_docs.py
+++ b/nodl/doc/package_docs.py
@@ -27,6 +27,7 @@ PACKAGES = [
     'nodl_common_interfaces',
     'nodl_generator_cpp',
     'nodl_docgen',
+    'nodl_conformance',
 ]
 
 # Toctree entries, relative to the Sphinx source dir (== _HERE), mirrored by the "Packages" toctree in index.md.

--- a/nodl_conformance/doc/conf.py
+++ b/nodl_conformance/doc/conf.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Sphinx configuration for standalone nodl_conformance documentation."""
+
+extensions = [
+    'myst_parser',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.extlinks',
+]
+
+intersphinx_mapping = {
+    'nodl': ('https://nodl.readthedocs.io/en/latest/', None),
+}
+
+extlinks = {
+    'repo': ('https://github.com/ros-tooling/nodl/blob/main/%s', '%s'),
+}

--- a/nodl_conformance/doc/overview.md
+++ b/nodl_conformance/doc/overview.md
@@ -20,38 +20,23 @@ means conformance. Each `Difference` contains `kind`, `section`, `name`, and
 Comparison is strict. Every declared public interface must be present in the
 actual document, and every actual public interface must be declared.
 
-The comparator handles these name forms:
-
-- `/status` stays absolute.
-- `status` resolves in the node namespace.
-- `~/status` resolves below the full node name.
-
-Short ROS interface types compare equal to their kind-specific fully qualified
-form. For example, `std_msgs/String` equals `std_msgs/msg/String` for a topic.
-
-Collection order, empty collections, description fields, and top-level
-`codegen` metadata do not affect the result. Publishers, subscriptions, service
-servers, service clients, action servers, and action clients remain separate
-interface collections.
-
-### QoS
-
-The comparator checks each declared topic QoS policy present in the actual
-document. An omitted optional policy places no requirement on the actual
-endpoint. `SYSTEM_DEFAULT` and `BEST_AVAILABLE` accept a concrete actual policy.
-
-`KEEP_LAST` requires a matching depth. Other history policies ignore depth. An
-omitted duration and zero both mean unlimited. Finite nonzero durations must
-match exactly.
-
-### Parameters
-
-The comparator checks parameter name, type, and `read_only`. It ignores
-`description`, `default_value`, `additional_constraints`, and validation rules.
-The actual current value does not represent the declared default.
-
-A generic actual parameter type cannot prove a declared fixed-size type. This
-case produces an `unverifiable` difference.
+| Check | Rule |
+|---|---|
+| **Interfaces · membership** | Missing declared interfaces and extra actual interfaces are differences. |
+| **Interfaces · collections** | Publishers, subscriptions, service servers, service clients, action servers, and action clients remain separate. |
+| **Interfaces · names** | `/status` stays absolute, `status` resolves in the node namespace, and `~/status` resolves below the full node name. |
+| **Interfaces · types** | A short type equals its kind-specific fully qualified form. For example, `std_msgs/String` equals `std_msgs/msg/String` for a topic. |
+| **QoS · observability** | Declared QoS that is not observable produces an `unverifiable` difference. |
+| **QoS · optional policies** | An omitted expected policy places no requirement on the actual endpoint. `SYSTEM_DEFAULT` and `BEST_AVAILABLE` accept a concrete actual policy. |
+| **QoS · concrete policies** | An unknown actual policy is `unverifiable`. Otherwise, the actual policy must match. |
+| **QoS · history and depth** | `KEEP_LAST` requires a matching depth. Other history policies ignore depth. |
+| **QoS · durations** | Omitted and zero durations both mean unlimited. Finite nonzero durations must match exactly. |
+| **Parameters · membership** | Missing declared parameters and extra actual parameters are differences. |
+| **Parameters · type** | Types must match. A generic actual type cannot prove a declared fixed-size type and produces `unverifiable`. |
+| **Parameters · read-only** | A declared `read_only` value must match. An unknown actual value is `unverifiable`. |
+| **Parameters · ignored fields** | Description, default value, additional constraints, validation rules, and the actual current value do not affect the result. |
+| **Representation** | Collection order and empty collections do not affect the result. |
+| **Metadata** | Description fields and top-level `codegen` metadata do not affect the result. |
 
 ## Runtime integration
 

--- a/nodl_conformance/doc/overview.md
+++ b/nodl_conformance/doc/overview.md
@@ -17,26 +17,42 @@ means conformance. Each `Difference` contains `kind`, `section`, `name`, and
 
 ## Comparison rules
 
-Comparison is strict. Every declared public interface must be present in the
-actual document, and every actual public interface must be declared.
+### Interfaces
+
+Interfaces are the public communication endpoints exposed or consumed by a
+node.
 
 | Check | Rule |
 |---|---|
-| **Interfaces · membership** | Missing declared interfaces and extra actual interfaces are differences. |
-| **Interfaces · collections** | Publishers, subscriptions, service servers, service clients, action servers, and action clients remain separate. |
-| **Interfaces · names** | `/status` stays absolute, `status` resolves in the node namespace, and `~/status` resolves below the full node name. |
-| **Interfaces · types** | A short type equals its kind-specific fully qualified form. For example, `std_msgs/String` equals `std_msgs/msg/String` for a topic. |
-| **QoS · observability** | Declared QoS that is not observable produces an `unverifiable` difference. |
-| **QoS · optional policies** | An omitted expected policy places no requirement on the actual endpoint. `SYSTEM_DEFAULT` and `BEST_AVAILABLE` accept a concrete actual policy. |
-| **QoS · concrete policies** | An unknown actual policy is `unverifiable`. Otherwise, the actual policy must match. |
-| **QoS · history and depth** | `KEEP_LAST` requires a matching depth. Other history policies ignore depth. |
-| **QoS · durations** | Omitted and zero durations both mean unlimited. Finite nonzero durations must match exactly. |
-| **Parameters · membership** | Missing declared parameters and extra actual parameters are differences. |
-| **Parameters · type** | Types must match. A generic actual type cannot prove a declared fixed-size type and produces `unverifiable`. |
-| **Parameters · read-only** | A declared `read_only` value must match. An unknown actual value is `unverifiable`. |
-| **Parameters · ignored fields** | Description, default value, additional constraints, validation rules, and the actual current value do not affect the result. |
-| **Representation** | Collection order and empty collections do not affect the result. |
-| **Metadata** | Description fields and top-level `codegen` metadata do not affect the result. |
+| Membership | Missing declared interfaces and extra actual interfaces are differences. |
+| Collections | Publishers, subscriptions, service servers, service clients, action servers, and action clients remain separate. |
+| Names | `/status` stays absolute, `status` resolves in the node namespace, and `~/status` resolves below the full node name. |
+| Types | A short type equals its kind-specific fully qualified form. For example, `std_msgs/String` equals `std_msgs/msg/String` for a topic. |
+| Representation | Collection order and empty collections do not affect the result. |
+| Ignored metadata | Description fields and top-level `codegen` metadata do not affect the result. |
+
+### QoS
+
+Quality of Service (QoS) policies define how an endpoint communicates.
+
+| Check | Rule |
+|---|---|
+| Observability | Declared QoS that is not observable produces an `unverifiable` difference. |
+| Optional policies | An omitted expected policy places no requirement on the actual endpoint. `SYSTEM_DEFAULT` and `BEST_AVAILABLE` accept a concrete actual policy. |
+| Concrete policies | An unknown actual policy is `unverifiable`. Otherwise, the actual policy must match. |
+| History and depth | `KEEP_LAST` requires a matching depth. Other history policies ignore depth. |
+| Durations | Omitted and zero durations both mean unlimited. Finite nonzero durations must match exactly. |
+
+### Parameters
+
+Parameters are named configuration entries exposed by a node.
+
+| Check | Rule |
+|---|---|
+| Membership | Missing declared parameters and extra actual parameters are differences. |
+| Type | Types must match. A generic actual type cannot prove a declared fixed-size type and produces `unverifiable`. |
+| Read-only | A declared `read_only` value must match. An unknown actual value is `unverifiable`. |
+| Ignored fields | Description, default value, additional constraints, validation rules, and the actual current value do not affect the result. |
 
 ## Runtime integration
 

--- a/nodl_conformance/doc/overview.md
+++ b/nodl_conformance/doc/overview.md
@@ -56,4 +56,4 @@ case produces an `unverifiable` difference.
 ## Runtime integration
 
 `ros2nodl` loads and composes the expected document, describes a live node, and
-calls this comparator.
+calls this comparator through `ros2 nodl conform`.

--- a/nodl_conformance/doc/overview.md
+++ b/nodl_conformance/doc/overview.md
@@ -1,0 +1,59 @@
+# nodl_conformance
+
+`nodl_conformance` is a small Python library that compares two loaded NoDL
+documents. It does not load files, inspect running ROS nodes, or provide launch
+integration.
+
+```python
+from nodl_conformance import diff
+
+differences = diff(expected, actual, node_fqn='/robot/my_node')
+```
+
+`expected` and `actual` are `nodl_schema.NodlDocument` objects. An empty list
+means conformance. Each `Difference` contains `kind`, `section`, `name`, and
+`detail`. Supported kinds are `missing`, `extra`, `type_mismatch`,
+`qos_mismatch`, `property_mismatch`, and `unverifiable`.
+
+## Comparison rules
+
+Comparison is strict. Every declared public interface must be present in the
+actual document, and every actual public interface must be declared.
+
+The comparator handles these name forms:
+
+- `/status` stays absolute.
+- `status` resolves in the node namespace.
+- `~/status` resolves below the full node name.
+
+Short ROS interface types compare equal to their kind-specific fully qualified
+form. For example, `std_msgs/String` equals `std_msgs/msg/String` for a topic.
+
+Collection order, empty collections, description fields, and top-level
+`codegen` metadata do not affect the result. Publishers, subscriptions, service
+servers, service clients, action servers, and action clients remain separate
+interface collections.
+
+### QoS
+
+The comparator checks each declared topic QoS policy present in the actual
+document. An omitted optional policy places no requirement on the actual
+endpoint. `SYSTEM_DEFAULT` and `BEST_AVAILABLE` accept a concrete actual policy.
+
+`KEEP_LAST` requires a matching depth. Other history policies ignore depth. An
+omitted duration and zero both mean unlimited. Finite nonzero durations must
+match exactly.
+
+### Parameters
+
+The comparator checks parameter name, type, and `read_only`. It ignores
+`description`, `default_value`, `additional_constraints`, and validation rules.
+The actual current value does not represent the declared default.
+
+A generic actual parameter type cannot prove a declared fixed-size type. This
+case produces an `unverifiable` difference.
+
+## Runtime integration
+
+`ros2nodl` loads and composes the expected document, describes a live node, and
+calls this comparator.

--- a/nodl_conformance/nodl_conformance/__init__.py
+++ b/nodl_conformance/nodl_conformance/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Pure semantic comparison for NoDL node interface documents."""
+
+from nodl_conformance._diff import Difference, diff
+
+__all__ = [
+    'Difference',
+    'diff',
+]

--- a/nodl_conformance/nodl_conformance/_diff.py
+++ b/nodl_conformance/nodl_conformance/_diff.py
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Pure semantic diff for two NoDL node-interface documents."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from enum import Enum
+
+from nodl_schema.models import NodlDocument, ParameterDefinition, QosProfile
+
+_SECTION_ORDER = {
+    'publishers': 0,
+    'subscriptions': 1,
+    'service_servers': 2,
+    'service_clients': 3,
+    'action_servers': 4,
+    'action_clients': 5,
+    'parameters': 6,
+}
+_TYPE_NAMESPACE = {
+    'publishers': 'msg',
+    'subscriptions': 'msg',
+    'service_servers': 'srv',
+    'service_clients': 'srv',
+    'action_servers': 'action',
+    'action_clients': 'action',
+}
+_SELECTION_POLICIES = {'SYSTEM_DEFAULT', 'BEST_AVAILABLE'}
+_NODE_FQN = re.compile(r'^/[A-Za-z][A-Za-z0-9_/]*[A-Za-z0-9_]$|^/[A-Za-z]$')
+
+
+@dataclass(frozen=True)
+class Difference:
+    """One stable semantic difference between expected and actual NoDL documents."""
+
+    kind: str
+    section: str
+    name: str
+    detail: str
+
+    def __str__(self) -> str:
+        return f'[{self.kind}] {self.section} {self.name!r}: {self.detail}'
+
+
+def _value(value):
+    return value.value if isinstance(value, Enum) else value
+
+
+def _type_name(value) -> str:
+    return str(_value(value))
+
+
+def _normalize_type(type_name: str, section: str) -> str:
+    parts = type_name.split('/')
+    if len(parts) == 2:
+        return f'{parts[0]}/{_TYPE_NAMESPACE[section]}/{parts[1]}'
+    return type_name
+
+
+def _validate_node_fqn(node_fqn: str) -> None:
+    if not isinstance(node_fqn, str) or not _NODE_FQN.fullmatch(node_fqn) or '//' in node_fqn:
+        raise ValueError(f'node_fqn must be a fully qualified ROS node name, got {node_fqn!r}')
+
+
+def _resolve_name(name: str, node_fqn: str) -> str:
+    if name.startswith('/'):
+        return name
+    if name.startswith('~'):
+        suffix = name[1:].lstrip('/')
+        return f'{node_fqn}/{suffix}'
+    namespace = node_fqn.rsplit('/', 1)[0]
+    return f'{namespace}/{name}' if namespace else f'/{name}'
+
+
+def _difference(kind: str, section: str, name: str, detail: str) -> Difference:
+    return Difference(kind=kind, section=section, name=name, detail=detail)
+
+
+def _identity_groups(endpoints: Iterable, section: str, node_fqn: str) -> dict[str, dict[str, object]]:
+    groups: dict[str, dict[str, object]] = defaultdict(dict)
+    for endpoint in endpoints:
+        name = _resolve_name(endpoint.name, node_fqn)
+        type_name = _normalize_type(endpoint.type, section)
+        groups[name].setdefault(type_name, endpoint)
+    return groups
+
+
+def _policy_difference(
+    *,
+    expected,
+    actual,
+    field: str,
+    section: str,
+    name: str,
+) -> Difference | None:
+    expected_value = _value(expected)
+    actual_value = _value(actual)
+    if expected_value is None or expected_value in _SELECTION_POLICIES:
+        return None
+    if actual_value is None or actual_value in _SELECTION_POLICIES:
+        return _difference(
+            'unverifiable',
+            section,
+            name,
+            f'{field}: expected {expected_value}, observed value is unknown',
+        )
+    if expected_value != actual_value:
+        return _difference('qos_mismatch', section, name, f'{field}: expected {expected_value}, got {actual_value}')
+    return None
+
+
+def _duration_difference(
+    *,
+    expected: int | None,
+    actual: int | None,
+    field: str,
+    section: str,
+    name: str,
+) -> Difference | None:
+    if expected is None:
+        return None
+    expected_value = expected or None
+    actual_value = actual or None
+    if expected_value == actual_value:
+        return None
+    return _difference('qos_mismatch', section, name, f'{field}: expected {expected_value}, got {actual_value}')
+
+
+def _qos_differences(
+    expected: QosProfile,
+    actual: QosProfile | None,
+    section: str,
+    name: str,
+) -> list[Difference]:
+    if actual is None:
+        return [_difference('unverifiable', section, name, 'declared QoS is not observable')]
+
+    differences = []
+    for field in ('history', 'reliability', 'durability', 'liveliness'):
+        difference = _policy_difference(
+            expected=getattr(expected, field),
+            actual=getattr(actual, field),
+            field=field,
+            section=section,
+            name=name,
+        )
+        if difference is not None:
+            differences.append(difference)
+
+    if _value(expected.history) == 'KEEP_LAST':
+        if actual.depth is None:
+            differences.append(_difference('unverifiable', section, name, 'depth: observed value is unknown'))
+        elif expected.depth != actual.depth:
+            differences.append(
+                _difference('qos_mismatch', section, name, f'depth: expected {expected.depth}, got {actual.depth}')
+            )
+
+    for field in ('deadline_ns', 'lifespan_ns', 'liveliness_lease_duration_ns'):
+        difference = _duration_difference(
+            expected=getattr(expected, field),
+            actual=getattr(actual, field),
+            field=field,
+            section=section,
+            name=name,
+        )
+        if difference is not None:
+            differences.append(difference)
+    return differences
+
+
+def _endpoint_differences(
+    expected: Iterable,
+    actual: Iterable,
+    section: str,
+    node_fqn: str,
+    compare_properties: Callable[[object, object, str, str], list[Difference]],
+) -> list[Difference]:
+    expected_groups = _identity_groups(expected, section, node_fqn)
+    actual_groups = _identity_groups(actual, section, node_fqn)
+    differences = []
+
+    for name in sorted(set(expected_groups) | set(actual_groups)):
+        expected_types = expected_groups.get(name, {})
+        actual_types = actual_groups.get(name, {})
+        missing_types = sorted(set(expected_types) - set(actual_types))
+        extra_types = sorted(set(actual_types) - set(expected_types))
+
+        if len(missing_types) == 1 and len(extra_types) == 1:
+            differences.append(
+                _difference(
+                    'type_mismatch',
+                    section,
+                    name,
+                    f'expected {missing_types[0]!r}, got {extra_types[0]!r}',
+                )
+            )
+        else:
+            differences.extend(
+                _difference('missing', section, name, f'expected type {type_name!r} was not observed')
+                for type_name in missing_types
+            )
+            differences.extend(
+                _difference('extra', section, name, f'observed undeclared type {type_name!r}')
+                for type_name in extra_types
+            )
+
+        for type_name in sorted(set(expected_types) & set(actual_types)):
+            differences.extend(compare_properties(expected_types[type_name], actual_types[type_name], section, name))
+    return differences
+
+
+def _topic_properties(expected, actual, section: str, name: str) -> list[Difference]:
+    return _qos_differences(expected.qos, actual.qos, section, name)
+
+
+def _service_properties(expected, actual, section: str, name: str) -> list[Difference]:
+    if expected.qos is None:
+        return []
+    return _qos_differences(expected.qos, actual.qos, section, name)
+
+
+def _no_properties(expected, actual, section: str, name: str) -> list[Difference]:
+    del expected, actual, section, name
+    return []
+
+
+def _is_fixed_type(type_name: str) -> bool:
+    return '_fixed_' in type_name
+
+
+def _fixed_base_type(type_name: str) -> str:
+    return type_name.split('_fixed_', 1)[0]
+
+
+def _parameter_differences(
+    expected: dict[str, ParameterDefinition],
+    actual: dict[str, ParameterDefinition],
+) -> list[Difference]:
+    differences = []
+    for name in sorted(set(expected) | set(actual)):
+        if name not in actual:
+            differences.append(_difference('missing', 'parameters', name, 'declared parameter was not observed'))
+            continue
+        if name not in expected:
+            differences.append(_difference('extra', 'parameters', name, 'observed undeclared parameter'))
+            continue
+
+        expected_parameter = expected[name]
+        actual_parameter = actual[name]
+        expected_type = _type_name(expected_parameter.type)
+        actual_type = _type_name(actual_parameter.type)
+        if expected_type != actual_type:
+            if _is_fixed_type(expected_type) and _fixed_base_type(expected_type) == actual_type:
+                differences.append(
+                    _difference(
+                        'unverifiable',
+                        'parameters',
+                        name,
+                        f'fixed-size type {expected_type!r} cannot be proven from observed type {actual_type!r}',
+                    )
+                )
+            else:
+                differences.append(
+                    _difference(
+                        'type_mismatch',
+                        'parameters',
+                        name,
+                        f'expected {expected_type!r}, got {actual_type!r}',
+                    )
+                )
+
+        expected_read_only = expected_parameter.read_only
+        actual_read_only = actual_parameter.read_only
+        if expected_read_only is not None:
+            if actual_read_only is None:
+                differences.append(
+                    _difference('unverifiable', 'parameters', name, 'read_only: observed value is unknown')
+                )
+            elif expected_read_only != actual_read_only:
+                differences.append(
+                    _difference(
+                        'property_mismatch',
+                        'parameters',
+                        name,
+                        f'read_only: expected {expected_read_only}, got {actual_read_only}',
+                    )
+                )
+    return differences
+
+
+def _sort_key(difference: Difference) -> tuple:
+    return (
+        _SECTION_ORDER.get(difference.section, len(_SECTION_ORDER)),
+        difference.name,
+        difference.kind,
+        difference.detail,
+    )
+
+
+def diff(expected: NodlDocument, actual: NodlDocument, *, node_fqn: str) -> list[Difference]:
+    """Return stable semantic differences between declared and observed NoDL documents."""
+    if not isinstance(expected, NodlDocument) or not isinstance(actual, NodlDocument):
+        raise TypeError('expected and actual must be NodlDocument objects')
+    _validate_node_fqn(node_fqn)
+
+    differences = []
+    for section in ('publishers', 'subscriptions'):
+        differences.extend(
+            _endpoint_differences(
+                getattr(expected, section) or [],
+                getattr(actual, section) or [],
+                section,
+                node_fqn,
+                _topic_properties,
+            )
+        )
+    for section in ('service_servers', 'service_clients'):
+        differences.extend(
+            _endpoint_differences(
+                getattr(expected, section) or [],
+                getattr(actual, section) or [],
+                section,
+                node_fqn,
+                _service_properties,
+            )
+        )
+    for section in ('action_servers', 'action_clients'):
+        differences.extend(
+            _endpoint_differences(
+                getattr(expected, section) or [],
+                getattr(actual, section) or [],
+                section,
+                node_fqn,
+                _no_properties,
+            )
+        )
+    differences.extend(_parameter_differences(expected.parameters or {}, actual.parameters or {}))
+    return sorted(differences, key=_sort_key)

--- a/nodl_conformance/package.xml
+++ b/nodl_conformance/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>nodl_conformance</name>
+  <version>0.0.0</version>
+  <description>Pure semantic comparison for NoDL node interface documents.</description>
+  <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
+  <license>Apache-2.0</license>
+
+  <exec_depend>nodl_schema</exec_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/nodl_conformance/rosdoc2.yaml
+++ b/nodl_conformance/rosdoc2.yaml
@@ -1,0 +1,13 @@
+type: 'rosdoc2 config'
+version: 1
+
+---
+settings:
+    always_run_sphinx_apidoc: true
+    generate_package_index: true
+
+builders:
+    - sphinx: {
+        name: 'nodl_conformance',
+        output_dir: ''
+    }

--- a/nodl_conformance/setup.cfg
+++ b/nodl_conformance/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/nodl_conformance
+[install]
+install_scripts=$base/lib/nodl_conformance

--- a/nodl_conformance/setup.py
+++ b/nodl_conformance/setup.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+from setuptools import setup
+
+package_name = 'nodl_conformance'
+
+setup(
+    name=package_name,
+    version='0.0.0',
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    zip_safe=True,
+    extras_require={'test': ['pytest']},
+)

--- a/nodl_conformance/test/test_diff.py
+++ b/nodl_conformance/test/test_diff.py
@@ -1,0 +1,737 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""ROS-free tests for the NoDL semantic diff."""
+
+import pytest
+
+from nodl_conformance import Difference, diff
+from nodl_schema.models import (
+    ActionEndpoint,
+    Durability,
+    History,
+    Liveliness,
+    NodlDocument,
+    ParameterDefinition,
+    QosProfile,
+    Reliability,
+    ServiceEndpoint,
+    TopicEndpoint,
+)
+
+
+def _qos(
+    *,
+    history=History.KEEP_LAST,
+    depth=10,
+    reliability=Reliability.RELIABLE,
+    durability=Durability.VOLATILE,
+    deadline_ns=None,
+    lifespan_ns=None,
+    liveliness=Liveliness.AUTOMATIC,
+    liveliness_lease_duration_ns=None,
+):
+    return QosProfile(
+        history=history,
+        depth=depth,
+        reliability=reliability,
+        durability=durability,
+        deadline_ns=deadline_ns,
+        lifespan_ns=lifespan_ns,
+        liveliness=liveliness,
+        liveliness_lease_duration_ns=liveliness_lease_duration_ns,
+    )
+
+
+def _topic(name='/topic', type='std_msgs/msg/String', qos=None):
+    return TopicEndpoint(name=name, type=type, qos=qos or _qos())
+
+
+def _service(name='/service', type='std_srvs/srv/Trigger', qos=None):
+    return ServiceEndpoint(name=name, type=type, qos=qos)
+
+
+def _action(name='/action', type='example_interfaces/action/Fibonacci'):
+    return ActionEndpoint(name=name, type=type)
+
+
+def _document(**sections):
+    return NodlDocument(nodl_version=2, **sections)
+
+
+def _kinds(differences):
+    return [difference.kind for difference in differences]
+
+
+def test_empty_and_missing_collections_are_equal():
+    assert diff(_document(), _document(publishers=[]), node_fqn='/node') == []
+
+
+@pytest.mark.parametrize(
+    'section,endpoint',
+    [
+        ('publishers', _topic()),
+        ('subscriptions', _topic()),
+        ('service_servers', _service()),
+        ('service_clients', _service()),
+        ('action_servers', _action()),
+        ('action_clients', _action()),
+    ],
+)
+def test_all_endpoint_sections_report_missing_and_extra(section, endpoint):
+    missing = diff(_document(**{section: [endpoint]}), _document(), node_fqn='/node')
+    extra = diff(_document(), _document(**{section: [endpoint]}), node_fqn='/node')
+
+    assert [(item.kind, item.section) for item in missing] == [('missing', section)]
+    assert [(item.kind, item.section) for item in extra] == [('extra', section)]
+
+
+@pytest.mark.parametrize(
+    'section,expected,actual',
+    [
+        ('publishers', _topic(type='std_msgs/msg/String'), _topic(type='std_msgs/msg/Int32')),
+        ('subscriptions', _topic(type='std_msgs/msg/String'), _topic(type='std_msgs/msg/Int32')),
+        (
+            'service_servers',
+            _service(type='std_srvs/srv/Trigger'),
+            _service(type='std_srvs/srv/SetBool'),
+        ),
+        (
+            'service_clients',
+            _service(type='std_srvs/srv/Trigger'),
+            _service(type='std_srvs/srv/SetBool'),
+        ),
+        (
+            'action_servers',
+            _action(type='example_interfaces/action/Fibonacci'),
+            _action(type='nav2_msgs/action/NavigateToPose'),
+        ),
+        (
+            'action_clients',
+            _action(type='example_interfaces/action/Fibonacci'),
+            _action(type='nav2_msgs/action/NavigateToPose'),
+        ),
+    ],
+)
+def test_same_name_with_different_type_is_one_type_mismatch(section, expected, actual):
+    differences = diff(
+        _document(**{section: [expected]}),
+        _document(**{section: [actual]}),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['type_mismatch']
+
+
+@pytest.mark.parametrize(
+    'section,expected,actual',
+    [
+        ('publishers', _topic(type='std_msgs/String'), _topic(type='std_msgs/msg/String')),
+        ('service_clients', _service(type='std_srvs/Trigger'), _service(type='std_srvs/srv/Trigger')),
+        (
+            'action_servers',
+            _action(type='example_interfaces/Fibonacci'),
+            _action(type='example_interfaces/action/Fibonacci'),
+        ),
+    ],
+)
+def test_short_and_fully_qualified_types_are_equal(section, expected, actual):
+    assert (
+        diff(
+            _document(**{section: [expected]}),
+            _document(**{section: [actual]}),
+            node_fqn='/node',
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    'node_fqn,declared_name,observed_name',
+    [
+        ('/robot/controller', '/status', '/status'),
+        ('/node', 'status', '/status'),
+        ('/robot/controller', 'status', '/robot/status'),
+        ('/robot/controller', '~/status', '/robot/controller/status'),
+    ],
+)
+def test_ros_names_resolve_against_node_identity(node_fqn, declared_name, observed_name):
+    assert (
+        diff(
+            _document(publishers=[_topic(name=declared_name)]),
+            _document(publishers=[_topic(name=observed_name)]),
+            node_fqn=node_fqn,
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    'section,endpoint',
+    [
+        ('publishers', _topic()),
+        ('subscriptions', _topic()),
+        ('service_servers', _service()),
+        ('service_clients', _service()),
+        ('action_servers', _action()),
+        ('action_clients', _action()),
+    ],
+)
+def test_endpoint_rename_reports_missing_and_extra(section, endpoint):
+    actual = endpoint.copy(update={'name': '/renamed'})
+
+    differences = diff(
+        _document(**{section: [endpoint]}),
+        _document(**{section: [actual]}),
+        node_fqn='/node',
+    )
+
+    assert sorted(_kinds(differences)) == ['extra', 'missing']
+
+
+@pytest.mark.parametrize(
+    'expected_qos,actual_qos,fields',
+    [
+        (
+            _qos(depth=10, reliability=Reliability.RELIABLE),
+            _qos(depth=5, reliability=Reliability.BEST_EFFORT),
+            {'depth', 'reliability'},
+        ),
+        (
+            _qos(durability=Durability.VOLATILE, liveliness=Liveliness.AUTOMATIC),
+            _qos(
+                durability=Durability.TRANSIENT_LOCAL,
+                liveliness=Liveliness.MANUAL_BY_TOPIC,
+            ),
+            {'durability', 'liveliness'},
+        ),
+        (
+            _qos(deadline_ns=10, lifespan_ns=10),
+            _qos(deadline_ns=20, lifespan_ns=20),
+            {'deadline_ns', 'lifespan_ns'},
+        ),
+    ],
+    ids=['depth-reliability', 'durability-liveliness', 'deadline-lifespan'],
+)
+def test_two_qos_fields_report_exactly_two_differences(expected_qos, actual_qos, fields):
+    differences = diff(
+        _document(publishers=[_topic(qos=expected_qos)]),
+        _document(publishers=[_topic(qos=actual_qos)]),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['qos_mismatch', 'qos_mismatch']
+    assert {item.detail.split(':', 1)[0] for item in differences} == fields
+
+
+@pytest.mark.parametrize(
+    'expected,actual,expected_kinds',
+    [
+        (
+            _document(publishers=[_topic('/qos'), _topic('/typed')]),
+            _document(
+                publishers=[
+                    _topic('/qos', qos=_qos(durability=Durability.TRANSIENT_LOCAL)),
+                    _topic('/typed', type='std_msgs/msg/Int32'),
+                ]
+            ),
+            ['qos_mismatch', 'type_mismatch'],
+        ),
+        (
+            _document(
+                publishers=[_topic('/state')],
+                parameters={'rate': ParameterDefinition(type='double')},
+            ),
+            _document(
+                publishers=[_topic('/state', qos=_qos(durability=Durability.TRANSIENT_LOCAL))],
+                parameters={'rate': ParameterDefinition(type='int')},
+            ),
+            ['qos_mismatch', 'type_mismatch'],
+        ),
+        (
+            _document(
+                service_servers=[_service('/reset')],
+                action_clients=[_action('/navigate')],
+            ),
+            _document(
+                service_servers=[_service('/reset', 'std_srvs/srv/SetBool')],
+                action_clients=[_action('/navigate', 'nav2_msgs/action/NavigateToPose')],
+            ),
+            ['type_mismatch', 'type_mismatch'],
+        ),
+        (
+            _document(
+                publishers=[_topic('/state')],
+                parameters={'mode': ParameterDefinition(type='string', read_only=True)},
+            ),
+            _document(parameters={'mode': ParameterDefinition(type='string', read_only=False)}),
+            ['missing', 'property_mismatch'],
+        ),
+        (
+            _document(parameters={'required': ParameterDefinition(type='string')}),
+            _document(subscriptions=[_topic('/command')]),
+            ['extra', 'missing'],
+        ),
+        (
+            _document(action_clients=[_action('/navigate')]),
+            _document(
+                action_clients=[_action('/navigate', 'nav2_msgs/action/NavigateToPose')],
+                parameters={'extra': ParameterDefinition(type='bool')},
+            ),
+            ['type_mismatch', 'extra'],
+        ),
+        (
+            _document(
+                publishers=[_topic('/state')],
+                subscriptions=[_topic('/command')],
+            ),
+            _document(
+                publishers=[_topic('/state', qos=_qos(durability=Durability.TRANSIENT_LOCAL))],
+                subscriptions=[_topic('/command', qos=_qos(reliability=Reliability.BEST_EFFORT))],
+            ),
+            ['qos_mismatch', 'qos_mismatch'],
+        ),
+    ],
+    ids=[
+        'type-and-qos',
+        'qos-and-parameter-type',
+        'service-and-action-types',
+        'missing-endpoint-and-parameter-property',
+        'extra-endpoint-and-missing-parameter',
+        'action-type-and-extra-parameter',
+        'publisher-and-subscription-qos',
+    ],
+)
+def test_two_independent_fields_report_exactly_two_differences(expected, actual, expected_kinds):
+    differences = diff(expected, actual, node_fqn='/node')
+
+    assert _kinds(differences) == expected_kinds
+    assert len(differences) == 2
+
+
+def test_declared_selection_policies_accept_observed_concrete_values():
+    expected = _topic(
+        qos=_qos(
+            history=History.SYSTEM_DEFAULT,
+            depth=None,
+            reliability=Reliability.BEST_AVAILABLE,
+            durability=Durability.SYSTEM_DEFAULT,
+            liveliness=Liveliness.BEST_AVAILABLE,
+        )
+    )
+
+    assert (
+        diff(
+            _document(publishers=[expected]),
+            _document(publishers=[_topic()]),
+            node_fqn='/node',
+        )
+        == []
+    )
+
+
+def test_unknown_observed_policy_cannot_prove_concrete_requirement():
+    actual = _topic(qos=_qos(reliability=Reliability.SYSTEM_DEFAULT))
+
+    differences = diff(
+        _document(publishers=[_topic()]),
+        _document(publishers=[actual]),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['unverifiable']
+    assert differences[0].detail.startswith('reliability:')
+
+
+@pytest.mark.parametrize(
+    'field,expected_value,actual_value',
+    [
+        ('history', History.KEEP_ALL, History.KEEP_LAST),
+        ('reliability', Reliability.RELIABLE, Reliability.BEST_EFFORT),
+        ('durability', Durability.VOLATILE, Durability.TRANSIENT_LOCAL),
+        ('liveliness', Liveliness.AUTOMATIC, Liveliness.MANUAL_BY_TOPIC),
+    ],
+)
+def test_each_concrete_qos_policy_detects_mismatch(field, expected_value, actual_value):
+    expected_kwargs = {field: expected_value}
+    actual_kwargs = {field: actual_value}
+    if field == 'history':
+        expected_kwargs['depth'] = None
+
+    differences = diff(
+        _document(publishers=[_topic(qos=_qos(**expected_kwargs))]),
+        _document(publishers=[_topic(qos=_qos(**actual_kwargs))]),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['qos_mismatch']
+    assert differences[0].detail.startswith(f'{field}:')
+
+
+def test_concrete_qos_depth_detects_mismatch():
+    differences = diff(
+        _document(publishers=[_topic(qos=_qos(depth=10))]),
+        _document(publishers=[_topic(qos=_qos(depth=20))]),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['qos_mismatch']
+    assert differences[0].detail.startswith('depth:')
+
+
+@pytest.mark.parametrize('section', ['publishers', 'subscriptions', 'service_servers', 'service_clients'])
+def test_qos_comparison_is_routed_for_every_supported_section(section):
+    endpoint = _topic if section in ('publishers', 'subscriptions') else _service
+    expected = endpoint(qos=_qos(durability=Durability.VOLATILE))
+    actual = endpoint(qos=_qos(durability=Durability.TRANSIENT_LOCAL))
+
+    differences = diff(
+        _document(**{section: [expected]}),
+        _document(**{section: [actual]}),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['qos_mismatch']
+
+
+def test_omitted_optional_qos_places_no_requirement():
+    expected = _topic(qos=_qos(durability=None, liveliness=None))
+    actual = _topic(qos=_qos(durability=Durability.TRANSIENT_LOCAL, liveliness=Liveliness.MANUAL_BY_TOPIC))
+
+    assert (
+        diff(
+            _document(publishers=[expected]),
+            _document(publishers=[actual]),
+            node_fqn='/node',
+        )
+        == []
+    )
+
+
+def test_zero_and_omitted_unlimited_duration_are_equal():
+    expected = _topic(qos=_qos(deadline_ns=0))
+    actual = _topic(qos=_qos(deadline_ns=None))
+
+    assert (
+        diff(
+            _document(publishers=[expected]),
+            _document(publishers=[actual]),
+            node_fqn='/node',
+        )
+        == []
+    )
+
+
+def test_finite_and_unlimited_duration_are_a_mismatch():
+    differences = diff(
+        _document(publishers=[_topic(qos=_qos(deadline_ns=10))]),
+        _document(publishers=[_topic(qos=_qos(deadline_ns=None))]),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['qos_mismatch']
+    assert differences[0].detail == 'deadline_ns: expected 10, got None'
+
+
+@pytest.mark.parametrize('field', ['deadline_ns', 'lifespan_ns', 'liveliness_lease_duration_ns'])
+def test_each_finite_qos_duration_detects_mismatch(field):
+    differences = diff(
+        _document(publishers=[_topic(qos=_qos(**{field: 10}))]),
+        _document(publishers=[_topic(qos=_qos(**{field: 20}))]),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['qos_mismatch']
+    assert differences[0].detail.startswith(f'{field}:')
+
+
+def test_missing_observed_depth_is_unverifiable():
+    actual = _topic(qos=_qos(depth=None))
+
+    differences = diff(
+        _document(publishers=[_topic()]),
+        _document(publishers=[actual]),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['unverifiable']
+    assert differences[0].detail.startswith('depth:')
+
+
+def test_declared_service_qos_is_unverifiable_when_observation_omits_it():
+    expected = _service(qos=_qos())
+
+    differences = diff(
+        _document(service_servers=[expected]),
+        _document(service_servers=[_service()]),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['unverifiable']
+
+
+def test_observable_matching_service_qos_conforms():
+    service = _service(qos=_qos())
+
+    assert (
+        diff(
+            _document(service_servers=[service]),
+            _document(service_servers=[service]),
+            node_fqn='/node',
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    'expected,actual,kind',
+    [
+        (
+            {'declared': ParameterDefinition(type='string')},
+            {},
+            'missing',
+        ),
+        (
+            {},
+            {'undeclared': ParameterDefinition(type='string')},
+            'extra',
+        ),
+        (
+            {'rate': ParameterDefinition(type='double')},
+            {'rate': ParameterDefinition(type='int')},
+            'type_mismatch',
+        ),
+        (
+            {'mode': ParameterDefinition(type='string', read_only=True)},
+            {'mode': ParameterDefinition(type='string', read_only=False)},
+            'property_mismatch',
+        ),
+    ],
+    ids=['missing', 'extra', 'type', 'read-only'],
+)
+def test_each_parameter_difference_individually(expected, actual, kind):
+    differences = diff(
+        _document(parameters=expected),
+        _document(parameters=actual),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == [kind]
+
+
+def test_parameter_rename_reports_missing_and_extra():
+    differences = diff(
+        _document(parameters={'old_name': ParameterDefinition(type='string')}),
+        _document(parameters={'new_name': ParameterDefinition(type='string')}),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['extra', 'missing']
+
+
+def test_many_differences_are_all_reported():
+    expected = _document(
+        publishers=[_topic('/state'), _topic('/telemetry')],
+        subscriptions=[_topic('/command')],
+        service_servers=[_service('/reset')],
+        action_clients=[_action('/navigate')],
+        parameters={
+            'mode': ParameterDefinition(type='string', read_only=True),
+            'rate': ParameterDefinition(type='double'),
+            'required': ParameterDefinition(type='bool'),
+        },
+    )
+    actual = _document(
+        publishers=[
+            _topic('/status'),
+            _topic('/telemetry', qos=_qos(durability=Durability.TRANSIENT_LOCAL)),
+        ],
+        subscriptions=[_topic('/command', type='std_msgs/msg/Int32')],
+        action_clients=[_action('/navigate', 'nav2_msgs/action/NavigateToPose')],
+        parameters={
+            'extra': ParameterDefinition(type='bool'),
+            'mode': ParameterDefinition(type='string', read_only=False),
+            'rate': ParameterDefinition(type='int'),
+        },
+    )
+
+    differences = diff(expected, actual, node_fqn='/node')
+
+    assert differences == [
+        Difference('missing', 'publishers', '/state', "expected type 'std_msgs/msg/String' was not observed"),
+        Difference('extra', 'publishers', '/status', "observed undeclared type 'std_msgs/msg/String'"),
+        Difference(
+            'qos_mismatch',
+            'publishers',
+            '/telemetry',
+            'durability: expected VOLATILE, got TRANSIENT_LOCAL',
+        ),
+        Difference(
+            'type_mismatch',
+            'subscriptions',
+            '/command',
+            "expected 'std_msgs/msg/String', got 'std_msgs/msg/Int32'",
+        ),
+        Difference(
+            'missing',
+            'service_servers',
+            '/reset',
+            "expected type 'std_srvs/srv/Trigger' was not observed",
+        ),
+        Difference(
+            'type_mismatch',
+            'action_clients',
+            '/navigate',
+            "expected 'example_interfaces/action/Fibonacci', got 'nav2_msgs/action/NavigateToPose'",
+        ),
+        Difference('extra', 'parameters', 'extra', 'observed undeclared parameter'),
+        Difference('property_mismatch', 'parameters', 'mode', 'read_only: expected True, got False'),
+        Difference('type_mismatch', 'parameters', 'rate', "expected 'double', got 'int'"),
+        Difference('missing', 'parameters', 'required', 'declared parameter was not observed'),
+    ]
+
+
+def test_fixed_size_parameter_cannot_be_proven_from_runtime_base_type():
+    differences = diff(
+        _document(parameters={'names': ParameterDefinition(type='string_array_fixed_3')}),
+        _document(parameters={'names': ParameterDefinition(type='string_array')}),
+        node_fqn='/node',
+    )
+
+    assert _kinds(differences) == ['unverifiable']
+
+
+def test_parameter_values_and_metadata_do_not_affect_conformance():
+    expected = ParameterDefinition(
+        type='double',
+        default_value=1.0,
+        description='declared description',
+        additional_constraints='declared constraint',
+    )
+    actual = ParameterDefinition(
+        type='double',
+        default_value=9.0,
+        description='observed description',
+        additional_constraints='observed constraint',
+    )
+
+    assert (
+        diff(
+            _document(parameters={'rate': expected}),
+            _document(parameters={'rate': actual}),
+            node_fqn='/node',
+        )
+        == []
+    )
+
+
+def test_parameter_validation_does_not_affect_conformance():
+    assert (
+        diff(
+            _document(parameters={'rate': ParameterDefinition(type='double', validation={'bounds': [0.0, 1.0]})}),
+            _document(parameters={'rate': ParameterDefinition(type='double', validation={'bounds': [-1.0, 2.0]})}),
+            node_fqn='/node',
+        )
+        == []
+    )
+
+
+def test_document_description_does_not_affect_conformance():
+    assert (
+        diff(
+            _document(description='declared description'),
+            _document(description='observed description'),
+            node_fqn='/node',
+        )
+        == []
+    )
+
+
+def test_codegen_metadata_does_not_affect_conformance():
+    assert (
+        diff(
+            _document(codegen={'cpp': {'role': 'base_class'}}),
+            _document(codegen={'python': {'role': 'wrapper'}}),
+            node_fqn='/node',
+        )
+        == []
+    )
+
+
+def test_exact_duplicate_endpoints_do_not_create_instance_count_differences():
+    topic = _topic()
+
+    assert (
+        diff(
+            _document(publishers=[topic, topic]),
+            _document(publishers=[topic]),
+            node_fqn='/node',
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    'section,endpoint',
+    [
+        ('publishers', _topic()),
+        ('service_servers', _service()),
+        ('action_servers', _action()),
+    ],
+)
+def test_endpoint_descriptions_do_not_affect_conformance(section, endpoint):
+    expected = endpoint.copy(deep=True)
+    actual = endpoint.copy(deep=True)
+    expected.description = 'declared description'
+    actual.description = 'observed description'
+
+    assert (
+        diff(
+            _document(**{section: [expected]}),
+            _document(**{section: [actual]}),
+            node_fqn='/node',
+        )
+        == []
+    )
+
+
+def test_diagnostics_have_stable_section_name_kind_order():
+    expected = _document(
+        publishers=[_topic('/z'), _topic('/a')],
+        parameters={'z': ParameterDefinition(type='string')},
+    )
+    actual = _document(subscriptions=[_topic('/b')])
+
+    forward = diff(expected, actual, node_fqn='/node')
+    reordered = diff(
+        _document(
+            publishers=[_topic('/a'), _topic('/z')],
+            parameters={'z': ParameterDefinition(type='string')},
+        ),
+        actual,
+        node_fqn='/node',
+    )
+
+    assert [str(item) for item in forward] == [str(item) for item in reordered]
+    assert [(item.section, item.name) for item in forward] == [
+        ('publishers', '/a'),
+        ('publishers', '/z'),
+        ('subscriptions', '/b'),
+        ('parameters', 'z'),
+    ]
+
+
+def test_difference_string_is_stable_and_readable():
+    difference = Difference('missing', 'publishers', '/scan', 'expected type was not observed')
+
+    assert str(difference) == "[missing] publishers '/scan': expected type was not observed"
+
+
+@pytest.mark.parametrize('node_fqn', ['node', '/', '/node/', '/node//child', ''])
+def test_invalid_node_fqn_is_rejected(node_fqn):
+    with pytest.raises(ValueError, match='fully qualified ROS node name'):
+        diff(_document(), _document(), node_fqn=node_fqn)
+
+
+def test_non_document_inputs_are_rejected():
+    with pytest.raises(TypeError, match='NodlDocument'):
+        diff({}, _document(), node_fqn='/node')

--- a/nodl_conformance/test/test_imports.py
+++ b/nodl_conformance/test/test_imports.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Dependency-boundary tests for the pure comparison package."""
+
+import subprocess
+import sys
+
+
+def test_public_package_does_not_import_runtime_or_launch_packages():
+    script = """
+import sys
+import nodl_conformance
+
+blocked = ('ros2nodl', 'launch', 'launch_ros', 'launch_testing', 'rclpy')
+assert nodl_conformance.__all__ == ['Difference', 'diff']
+assert not any(
+    name == prefix or name.startswith(f'{prefix}.')
+    for prefix in blocked
+    for name in sys.modules
+)
+"""
+
+    subprocess.run([sys.executable, '-c', script], check=True)

--- a/ros2nodl/doc/conformance.md
+++ b/ros2nodl/doc/conformance.md
@@ -1,30 +1,13 @@
-# Check conformance from Python
+# Conform
 
-`ros2nodl.conformance` manages the runtime part of a conformance check. It loads
-and composes an explicit NoDL file, describes the running node, and passes the
-two documents to `nodl_conformance.diff`.
+Check whether a running node conforms to an explicit NoDL document:
 
-Use `check_conformance` when code must inspect each difference:
-
-```python
-from ros2nodl.conformance import check_conformance
-
-differences = check_conformance(
-    nodl_file='nodl/my_node.nodl.yaml',
-    node_fqn='/robot/my_node',
-    timeout_sec=15.0,
-)
+```console
+ros2 nodl conform NODE_NAME --file FILE [--timeout SEC]
 ```
 
-Use `assert_conforms` when an aggregated `AssertionError` is more convenient:
-
-```python
-from ros2nodl.conformance import assert_conforms
-
-assert_conforms(
-    nodl_file='nodl/my_node.nodl.yaml',
-    node_fqn='/robot/my_node',
-)
+```console
+ros2 nodl conform /robot/my_node --file nodl/my_node.nodl.yaml
 ```
 
 The file is the explicit root contract. Its `include` references are resolved
@@ -35,5 +18,6 @@ the check before runtime observation. A description failure stops comparison.
 Description gaps become `unverifiable` differences with their original path and
 reason. Semantic differences are aggregated and sorted for stable diagnostics.
 
-This API deliberately does not infer a document from the `nodl_nodes` resource
-index and does not add a `ros2 nodl conform` command.
+The command exits zero when the node conforms. Otherwise, it prints every
+difference and exits nonzero. It does not infer a document from the `nodl_nodes`
+resource index.

--- a/ros2nodl/doc/conformance.md
+++ b/ros2nodl/doc/conformance.md
@@ -1,0 +1,39 @@
+# Check conformance from Python
+
+`ros2nodl.conformance` manages the runtime part of a conformance check. It loads
+and composes an explicit NoDL file, describes the running node, and passes the
+two documents to `nodl_conformance.diff`.
+
+Use `check_conformance` when code must inspect each difference:
+
+```python
+from ros2nodl.conformance import check_conformance
+
+differences = check_conformance(
+    nodl_file='nodl/my_node.nodl.yaml',
+    node_fqn='/robot/my_node',
+    timeout_sec=15.0,
+)
+```
+
+Use `assert_conforms` when an aggregated `AssertionError` is more convenient:
+
+```python
+from ros2nodl.conformance import assert_conforms
+
+assert_conforms(
+    nodl_file='nodl/my_node.nodl.yaml',
+    node_fqn='/robot/my_node',
+)
+```
+
+The file is the explicit root contract. Its `include` references are resolved
+recursively through the standard `nodl_schema` resolvers before the node is
+described. An unresolved reference, invalid document, or merge collision stops
+the check before runtime observation. A description failure stops comparison.
+
+Description gaps become `unverifiable` differences with their original path and
+reason. Semantic differences are aggregated and sorted for stable diagnostics.
+
+This API deliberately does not infer a document from the `nodl_nodes` resource
+index and does not add a `ros2 nodl conform` command.

--- a/ros2nodl/doc/overview.md
+++ b/ros2nodl/doc/overview.md
@@ -17,6 +17,16 @@ conformance
 
 Running `ros2 nodl` with no verb prints help. The available verbs:
 
+### `ros2 nodl conform`
+
+Check a running node against an explicit NoDL document.
+
+```console
+ros2 nodl conform /robot/my_node --file nodl/my_node.nodl.yaml
+```
+
+See the [Conform guide](conformance.md) for composition, diagnostics, and exit behavior.
+
 ### `ros2 nodl validate [files...]`
 
 Validate one or more NoDL documents against the NoDL schema.
@@ -49,12 +59,6 @@ ros2 nodl describe /ns/talker --from talker.mcap -o talker.json
 ```
 
 See the [Describe guide](describe.md) for each option and the ROS-to-NoDL mapping.
-
-## Runtime conformance API
-
-The [Conformance guide](conformance.md) documents the Python API that compares
-an explicit NoDL contract with a fresh description of a running node. This is a
-library API; this release does not add a `ros2 nodl conform` command.
 
 ## Relationship to other packages
 

--- a/ros2nodl/doc/overview.md
+++ b/ros2nodl/doc/overview.md
@@ -12,6 +12,7 @@ For the Python API that backs this command, see the `nodl_schema` package.
 :hidden:
 
 describe
+conformance
 ```
 
 Running `ros2 nodl` with no verb prints help. The available verbs:
@@ -48,6 +49,12 @@ ros2 nodl describe /ns/talker --from talker.mcap -o talker.json
 ```
 
 See the [Describe guide](describe.md) for each option and the ROS-to-NoDL mapping.
+
+## Runtime conformance API
+
+The [Conformance guide](conformance.md) documents the Python API that compares
+an explicit NoDL contract with a fresh description of a running node. This is a
+library API; this release does not add a `ros2 nodl conform` command.
 
 ## Relationship to other packages
 

--- a/ros2nodl/package.xml
+++ b/ros2nodl/package.xml
@@ -10,6 +10,7 @@
   <author email="me@emersonknapp.com">Emerson Knapp</author>
 
   <depend>nodl_observe</depend>
+  <depend>nodl_conformance</depend>
   <depend>nodl_schema</depend>
   <depend>rosgraph_msgs</depend>
   <depend>ros2cli</depend>

--- a/ros2nodl/ros2nodl/conformance.py
+++ b/ros2nodl/ros2nodl/conformance.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime orchestration for NoDL conformance checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nodl_conformance import Difference, diff
+from nodl_schema import load_nodl
+
+
+def _load_document(nodl_file: str):
+    path = Path(nodl_file)
+    try:
+        return load_nodl(path)
+    except Exception as exc:
+        raise ValueError(f'failed to load NoDL document {str(path)!r}: {exc}') from exc
+
+
+def _gap_difference(gap) -> Difference:
+    section = gap.path.split('[', 1)[0].split('.', 1)[0]
+    return Difference(
+        kind='unverifiable',
+        section=section,
+        name=gap.path,
+        detail=gap.reason,
+    )
+
+
+def _sort_key(difference: Difference) -> tuple[str, str, str, str]:
+    return difference.section, difference.name, difference.kind, difference.detail
+
+
+def check_conformance(
+    *,
+    nodl_file: str,
+    node_fqn: str,
+    timeout_sec: float = 15.0,
+) -> list[Difference]:
+    """Compare one running node with one explicit NoDL document."""
+    expected = _load_document(nodl_file)
+
+    from ros2nodl.describe import DescribeOptions, describe_node
+
+    result = describe_node(
+        node_fqn,
+        timeout_sec=timeout_sec,
+        options=DescribeOptions(include_parameters=True, keep_hidden=False),
+    )
+    differences = [_gap_difference(gap) for gap in result.gaps]
+    differences.extend(diff(expected, result.doc, node_fqn=node_fqn))
+    return sorted(differences, key=_sort_key)
+
+
+def assert_conforms(
+    *,
+    nodl_file: str,
+    node_fqn: str,
+    timeout_sec: float = 15.0,
+) -> None:
+    """Raise one assertion that contains every conformance difference."""
+    differences = check_conformance(
+        nodl_file=nodl_file,
+        node_fqn=node_fqn,
+        timeout_sec=timeout_sec,
+    )
+    if differences:
+        rendered = '\n'.join(f'  {difference}' for difference in differences)
+        raise AssertionError(f'NoDL conformance failed for {node_fqn!r}:\n{rendered}')

--- a/ros2nodl/ros2nodl/describe/__init__.py
+++ b/ros2nodl/ros2nodl/describe/__init__.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
 # SPDX-License-Identifier: Apache-2.0
-"""Public API for converting an observed Node message to a NoDL draft."""
+"""Public API for describing observed and live ROS nodes as NoDL."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING
+from uuid import uuid4
 
 if TYPE_CHECKING:
     from nodl_schema.models import NodlDocument
@@ -27,11 +28,30 @@ class DescribeOptions:
 
 @dataclass
 class DescribeResult:
-    doc: 'NodlDocument'
-    gaps: List[Gap] = field(default_factory=list)
+    doc: NodlDocument
+    gaps: list[Gap] = field(default_factory=list)
 
 
-def node_to_nodl(node, opts: Optional[DescribeOptions] = None) -> DescribeResult:
+def describe_node(
+    node_name: str,
+    *,
+    timeout_sec: float = 5.0,
+    options: DescribeOptions | None = None,
+) -> DescribeResult:
+    """Describe one running ROS node."""
+    from ros2nodl.describe._source import acquire_live
+
+    opts = options or DescribeOptions()
+    node = acquire_live(
+        node_name,
+        timeout_sec=timeout_sec,
+        include_parameters=opts.include_parameters,
+        topic=f'/nodl/observed_node_{uuid4().hex}',
+    )
+    return node_to_nodl(node, opts)
+
+
+def node_to_nodl(node, opts: DescribeOptions | None = None) -> DescribeResult:
     """Convert a duck-typed ``rosgraph_msgs/Node`` into a NoDL document."""
     from ros2nodl.describe._transform import convert
 

--- a/ros2nodl/ros2nodl/verb/conform.py
+++ b/ros2nodl/ros2nodl/verb/conform.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""``ros2 nodl conform`` -- check a running node against a NoDL document."""
+
+import sys
+from pathlib import Path
+
+from ros2nodl.verb import VerbExtension
+
+_DEFAULT_TIMEOUT = 15.0
+
+
+class ConformVerb(VerbExtension):
+    """Check whether a running node conforms to a NoDL document."""
+
+    def add_arguments(self, parser, cli_name):
+        parser.add_argument('node_name', metavar='NODE_NAME', help='Fully-qualified target node name.')
+        parser.add_argument(
+            '--file',
+            type=Path,
+            required=True,
+            metavar='FILE',
+            help='NoDL document that declares the expected interface.',
+        )
+        parser.add_argument(
+            '--timeout',
+            metavar='SEC',
+            type=float,
+            default=_DEFAULT_TIMEOUT,
+            help='Live discovery timeout in seconds (default: %(default)s).',
+        )
+
+    def main(self, *, args) -> int:
+        from ros2nodl.conformance import assert_conforms
+
+        try:
+            assert_conforms(
+                nodl_file=str(args.file),
+                node_fqn=args.node_name,
+                timeout_sec=args.timeout,
+            )
+        except Exception as exc:
+            print(f'ros2 nodl conform: {exc}', file=sys.stderr)
+            return 1
+        print(f'{args.node_name}: conforms')
+        return 0

--- a/ros2nodl/ros2nodl/verb/describe.py
+++ b/ros2nodl/ros2nodl/verb/describe.py
@@ -80,16 +80,14 @@ class DescribeVerb(VerbExtension):
         )
 
 
-def _acquire_node(*, node_name, from_file, timeout_sec, include_parameters):
-    from ros2nodl.describe import _source
+def _describe_source(*, node_name, from_file, timeout_sec, options):
+    from ros2nodl.describe import describe_node, node_to_nodl
 
     if from_file:
-        return _source.acquire_from_file(from_file)
-    return _source.acquire_live(
-        node_name,
-        timeout_sec=timeout_sec,
-        include_parameters=include_parameters,
-    )
+        from ros2nodl.describe._source import acquire_from_file
+
+        return node_to_nodl(acquire_from_file(from_file), options)
+    return describe_node(node_name, timeout_sec=timeout_sec, options=options)
 
 
 def _write(text: str, output_path) -> int:
@@ -117,34 +115,30 @@ def _run(
     output_path,
     output_format,
 ) -> int:
+    from ros2nodl.describe import DescribeOptions
     from ros2nodl.describe._source import SourceError
 
+    options = DescribeOptions(
+        include_parameters=include_parameters,
+        keep_hidden=keep_hidden,
+    )
+
     try:
-        message = _acquire_node(
+        result = _describe_source(
             node_name=node_name,
             from_file=from_file,
             timeout_sec=timeout_sec,
-            include_parameters=include_parameters,
+            options=options,
         )
     except SourceError as exc:
         print(f'ros2 nodl describe: {exc}', file=sys.stderr)
         return 1
-
-    from nodl_schema.loader import dump_nodl
-    from nodl_schema.validation import validate
-    from ros2nodl.describe import DescribeOptions, node_to_nodl
-
-    try:
-        result = node_to_nodl(
-            message,
-            DescribeOptions(
-                include_parameters=include_parameters,
-                keep_hidden=keep_hidden,
-            ),
-        )
     except Exception as exc:
         print(f'ros2 nodl describe: failed to interpret node: {exc}', file=sys.stderr)
         return 1
+
+    from nodl_schema.loader import dump_nodl
+    from nodl_schema.validation import validate
 
     try:
         validate(json.loads(result.doc.json(exclude_none=True)))

--- a/ros2nodl/setup.py
+++ b/ros2nodl/setup.py
@@ -22,6 +22,7 @@ setup(
             'ros2nodl.verb = ros2nodl.verb:VerbExtension',
         ],
         'ros2nodl.verb': [
+            'conform = ros2nodl.verb.conform:ConformVerb',
             'describe = ros2nodl.verb.describe:DescribeVerb',
             'rewrite = ros2nodl.verb.rewrite:RewriteVerb',
             'validate = ros2nodl.verb.validate:ValidateVerb',

--- a/ros2nodl/test/conformance/fixtures/minimal.nodl.json
+++ b/ros2nodl/test/conformance/fixtures/minimal.nodl.json
@@ -1,0 +1,3 @@
+{
+  "nodl_version": 2
+}

--- a/ros2nodl/test/conformance/fixtures/minimal.nodl.yaml
+++ b/ros2nodl/test/conformance/fixtures/minimal.nodl.yaml
@@ -1,0 +1,2 @@
+---
+nodl_version: 2

--- a/ros2nodl/test/conformance/test_conformance.py
+++ b/ros2nodl/test/conformance/test_conformance.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from nodl_conformance import Difference
+from nodl_schema import Resolver, dump_nodl, resolver_registered
+from nodl_schema.models import (
+    History,
+    NodlDocument,
+    QosProfile,
+    Reference,
+    Reliability,
+    TopicEndpoint,
+)
+from ros2nodl import conformance
+from ros2nodl.conformance import assert_conforms, check_conformance
+
+FIXTURES = Path(__file__).parent / 'fixtures'
+
+
+class _Resolver(Resolver):
+    scheme = 'test://'
+
+    def __init__(self, documents):
+        self.documents = documents
+
+    def handles(self, ref):
+        return ref.startswith(self.scheme)
+
+    def resolve(self, ref, origin=None):
+        del origin
+        return self.documents[ref]
+
+
+def _topic(name):
+    return TopicEndpoint(
+        name=name,
+        type='std_msgs/msg/String',
+        qos=QosProfile(
+            history=History.SYSTEM_DEFAULT,
+            reliability=Reliability.SYSTEM_DEFAULT,
+        ),
+    )
+
+
+def _minimal_document():
+    return NodlDocument()
+
+
+def _describe_result(*, gaps=None):
+    return SimpleNamespace(doc=_minimal_document(), gaps=gaps or [])
+
+
+def _patch_describe(monkeypatch, result):
+    import ros2nodl.describe
+
+    monkeypatch.setattr(ros2nodl.describe, 'describe_node', lambda *args, **kwargs: result)
+
+
+def _track_describe_calls(monkeypatch):
+    calls = []
+
+    def describe_node(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    import ros2nodl.describe
+
+    monkeypatch.setattr(ros2nodl.describe, 'describe_node', describe_node)
+    return calls
+
+
+@pytest.mark.parametrize('filename', ['minimal.nodl.yaml', 'minimal.nodl.json'])
+def test_check_conformance_loads_explicit_yaml_and_json(monkeypatch, filename):
+    _patch_describe(monkeypatch, _describe_result())
+
+    assert (
+        check_conformance(
+            nodl_file=str(FIXTURES / filename),
+            node_fqn='/fixture',
+        )
+        == []
+    )
+
+
+def test_check_conformance_uses_public_describe_path_once(monkeypatch):
+    calls = []
+
+    def describe_node(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _describe_result()
+
+    import ros2nodl.describe
+
+    monkeypatch.setattr(ros2nodl.describe, 'describe_node', describe_node)
+
+    assert (
+        check_conformance(
+            nodl_file=str(FIXTURES / 'minimal.nodl.yaml'),
+            node_fqn='/robot/fixture',
+            timeout_sec=3.0,
+        )
+        == []
+    )
+
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+    assert args == ('/robot/fixture',)
+    assert kwargs['timeout_sec'] == 3.0
+    assert kwargs['options'].include_parameters is True
+    assert kwargs['options'].keep_hidden is False
+
+
+def test_check_conformance_rejects_missing_file_before_describe(monkeypatch, tmp_path):
+    calls = _track_describe_calls(monkeypatch)
+    missing = tmp_path / 'missing.nodl.yaml'
+
+    with pytest.raises(ValueError, match=str(missing)):
+        check_conformance(nodl_file=str(missing), node_fqn='/fixture')
+
+    assert calls == []
+
+
+def test_check_conformance_compares_resolved_includes(monkeypatch, tmp_path):
+    included = NodlDocument(publishers=[_topic('/state')])
+    included_path = tmp_path / 'common.nodl.yaml'
+    included_path.write_text(dump_nodl(included), encoding='utf-8')
+    root = tmp_path / 'composed.nodl.yaml'
+    root.write_text(
+        dump_nodl(NodlDocument(include=[Reference(ref='test://common')])),
+        encoding='utf-8',
+    )
+    observed = _minimal_document()
+    _patch_describe(monkeypatch, SimpleNamespace(doc=observed, gaps=[]))
+    calls = []
+    monkeypatch.setattr(
+        conformance,
+        'diff',
+        lambda expected, actual, *, node_fqn: calls.append((expected, actual, node_fqn)) or [],
+    )
+
+    with resolver_registered(_Resolver({'test://common': included_path})):
+        assert check_conformance(nodl_file=str(root), node_fqn='/fixture') == []
+
+    expected, actual, node_fqn = calls[0]
+    assert expected.include is None
+    assert [publisher.name for publisher in expected.publishers] == ['/state']
+    assert actual is observed
+    assert node_fqn == '/fixture'
+
+
+def test_check_conformance_rejects_unresolved_include_before_describe(monkeypatch, tmp_path):
+    calls = _track_describe_calls(monkeypatch)
+    root = tmp_path / 'composed.nodl.yaml'
+    root.write_text(
+        dump_nodl(NodlDocument(include=[Reference(ref='test://missing')])),
+        encoding='utf-8',
+    )
+
+    with resolver_registered(_Resolver({})), pytest.raises(ValueError, match='test://missing'):
+        check_conformance(nodl_file=str(root), node_fqn='/fixture')
+
+    assert calls == []
+
+
+def test_check_conformance_rejects_include_collision_before_describe(monkeypatch, tmp_path):
+    calls = _track_describe_calls(monkeypatch)
+    duplicate = NodlDocument(publishers=[_topic('/state')])
+    duplicate_path = tmp_path / 'duplicate.nodl.yaml'
+    duplicate_path.write_text(dump_nodl(duplicate), encoding='utf-8')
+    root = tmp_path / 'composed.nodl.yaml'
+    root.write_text(
+        dump_nodl(
+            NodlDocument(
+                publishers=[_topic('/state')],
+                include=[Reference(ref='test://duplicate')],
+            )
+        ),
+        encoding='utf-8',
+    )
+
+    resolver = _Resolver({'test://duplicate': duplicate_path})
+    with resolver_registered(resolver), pytest.raises(ValueError, match='/state'):
+        check_conformance(nodl_file=str(root), node_fqn='/fixture')
+
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    'text',
+    [
+        'nodl_version: [',
+        '{"nodl_version":',
+        'nodl_version: 1',
+    ],
+)
+def test_check_conformance_rejects_invalid_documents(tmp_path, text):
+    invalid = tmp_path / 'invalid.nodl.yaml'
+    invalid.write_text(text, encoding='utf-8')
+
+    with pytest.raises(ValueError, match='failed to load NoDL document'):
+        check_conformance(nodl_file=str(invalid), node_fqn='/fixture')
+
+
+def test_check_conformance_propagates_describe_failure_without_diff(monkeypatch):
+    import ros2nodl.describe
+
+    def describe_node(*args, **kwargs):
+        raise RuntimeError('observation failed')
+
+    monkeypatch.setattr(ros2nodl.describe, 'describe_node', describe_node)
+    monkeypatch.setattr(conformance, 'diff', lambda *args, **kwargs: pytest.fail('diff called'))
+
+    with pytest.raises(RuntimeError, match='observation failed'):
+        check_conformance(
+            nodl_file=str(FIXTURES / 'minimal.nodl.yaml'),
+            node_fqn='/fixture',
+        )
+
+
+def test_check_conformance_converts_gaps_and_passes_only_documents_to_diff(monkeypatch):
+    from ros2nodl.describe import Gap
+
+    result = _describe_result(
+        gaps=[
+            Gap(path='publishers./state.qos', reason='QoS is unknown'),
+            Gap(path='parameters.mode.type', reason='type is unsupported'),
+        ]
+    )
+    _patch_describe(monkeypatch, result)
+    calls = []
+    comparison = Difference('extra', 'publishers', '/extra', 'observed undeclared type')
+
+    def compare(expected, actual, *, node_fqn):
+        calls.append((expected, actual, node_fqn))
+        return [comparison]
+
+    monkeypatch.setattr(conformance, 'diff', compare)
+
+    differences = check_conformance(
+        nodl_file=str(FIXTURES / 'minimal.nodl.yaml'),
+        node_fqn='/fixture',
+        timeout_sec=3.0,
+    )
+
+    assert calls[0][1] is result.doc
+    assert calls[0][2] == '/fixture'
+    assert {(difference.section, difference.name) for difference in differences} == {
+        ('parameters', 'parameters.mode.type'),
+        ('publishers', '/extra'),
+        ('publishers', 'publishers./state.qos'),
+    }
+    assert any('QoS is unknown' in str(difference) for difference in differences)
+
+
+def test_assert_conforms_aggregates_all_differences(monkeypatch):
+    differences = [
+        Difference('missing', 'publishers', '/state', 'not observed'),
+        Difference('extra', 'subscriptions', '/command', 'not declared'),
+    ]
+    monkeypatch.setattr(conformance, 'check_conformance', lambda **kwargs: differences)
+
+    with pytest.raises(AssertionError) as error:
+        assert_conforms(nodl_file='node.nodl.yaml', node_fqn='/fixture')
+
+    assert str(differences[0]) in str(error.value)
+    assert str(differences[1]) in str(error.value)

--- a/ros2nodl/test/describe/test_describe_node.py
+++ b/ros2nodl/test/describe/test_describe_node.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import ros2nodl.describe as describe_api
+from ros2nodl.describe import _source
+
+
+def test_describe_node_acquires_and_converts(monkeypatch):
+    observed = object()
+    described = object()
+    options = describe_api.DescribeOptions(include_parameters=False, keep_hidden=True)
+    calls = {}
+
+    def acquire_live(node_name, **kwargs):
+        calls['acquire'] = (node_name, kwargs)
+        return observed
+
+    def node_to_nodl(node, opts):
+        calls['convert'] = (node, opts)
+        return described
+
+    monkeypatch.setattr(_source, 'acquire_live', acquire_live)
+    monkeypatch.setattr(describe_api, 'node_to_nodl', node_to_nodl)
+
+    result = describe_api.describe_node('/robot/controller', timeout_sec=2.5, options=options)
+
+    assert result is described
+    assert calls['acquire'][0] == '/robot/controller'
+    assert calls['acquire'][1]['timeout_sec'] == 2.5
+    assert calls['acquire'][1]['include_parameters'] is False
+    assert calls['acquire'][1]['topic'].startswith('/nodl/observed_node_')
+    assert calls['convert'] == (observed, options)
+
+
+def test_describe_node_uses_defaults_and_isolates_transport(monkeypatch):
+    calls = []
+
+    def acquire_live(node_name, **kwargs):
+        calls.append((node_name, kwargs))
+        return object()
+
+    monkeypatch.setattr(_source, 'acquire_live', acquire_live)
+    monkeypatch.setattr(describe_api, 'node_to_nodl', lambda node, opts: (node, opts))
+
+    describe_api.describe_node('/first')
+    describe_api.describe_node('/second')
+
+    assert calls[0][1]['timeout_sec'] == 5.0
+    assert calls[0][1]['include_parameters'] is True
+    assert calls[0][1]['topic'] != calls[1][1]['topic']

--- a/ros2nodl/test/test_conform_verb.py
+++ b/ros2nodl/test/test_conform_verb.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+from pathlib import Path
+from unittest.mock import Mock
+
+from ros2nodl.verb.conform import ConformVerb
+
+
+def _args(**overrides):
+    values = {
+        'node_name': '/robot/controller',
+        'file': Path('nodl/controller.nodl.yaml'),
+        'timeout': 15.0,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_conform_passes_runtime_arguments(monkeypatch, capsys):
+    calls = []
+
+    def assert_conforms(**kwargs):
+        calls.append(kwargs)
+
+    import ros2nodl.conformance
+
+    monkeypatch.setattr(ros2nodl.conformance, 'assert_conforms', assert_conforms)
+
+    assert ConformVerb().main(args=_args(timeout=2.5)) == 0
+    assert calls == [
+        {
+            'nodl_file': 'nodl/controller.nodl.yaml',
+            'node_fqn': '/robot/controller',
+            'timeout_sec': 2.5,
+        }
+    ]
+    assert capsys.readouterr().out == '/robot/controller: conforms\n'
+
+
+def test_conform_reports_all_differences(monkeypatch, capsys):
+    message = "NoDL conformance failed for '/robot/controller':\n  [missing] publishers '/state': not observed"
+
+    import ros2nodl.conformance
+
+    monkeypatch.setattr(
+        ros2nodl.conformance,
+        'assert_conforms',
+        Mock(side_effect=AssertionError(message)),
+    )
+
+    assert ConformVerb().main(args=_args()) == 1
+    error = capsys.readouterr().err
+    assert error.startswith('ros2 nodl conform: NoDL conformance failed')
+    assert "[missing] publishers '/state': not observed" in error
+
+
+def test_conform_reports_runtime_errors(monkeypatch, capsys):
+    import ros2nodl.conformance
+
+    monkeypatch.setattr(
+        ros2nodl.conformance,
+        'assert_conforms',
+        Mock(side_effect=ValueError('failed to load document')),
+    )
+
+    assert ConformVerb().main(args=_args()) == 1
+    assert capsys.readouterr().err == 'ros2 nodl conform: failed to load document\n'
+
+
+def test_conform_arguments_are_required_and_typed():
+    parser = argparse.ArgumentParser()
+    ConformVerb().add_arguments(parser, 'ros2 nodl conform')
+
+    args = parser.parse_args(['/robot/controller', '--file', 'node.nodl.yaml', '--timeout', '3.5'])
+
+    assert args.node_name == '/robot/controller'
+    assert args.file == Path('node.nodl.yaml')
+    assert args.timeout == 3.5

--- a/ros2nodl/test/test_describe_verb.py
+++ b/ros2nodl/test/test_describe_verb.py
@@ -12,6 +12,7 @@ import yaml
 pytest.importorskip('ros2cli')
 rclpy = pytest.importorskip('rclpy')
 
+import ros2nodl.describe as describe_api  # noqa: E402
 from nodl_schema.validation import validate  # noqa: E402
 from ros2nodl.describe._source import observe_binary  # noqa: E402
 from ros2nodl.verb.describe import DescribeVerb, _infer_format  # noqa: E402
@@ -85,6 +86,25 @@ def test_from_yaml_writes_json(captured_node, tmp_path):
     output = tmp_path / 'description.json'
     assert DescribeVerb().main(args=_args(from_file=str(captured_node), output=str(output))) == 0
     assert json.loads(output.read_text())['nodl_version'] == 2
+
+
+def test_live_describe_uses_describe_node(monkeypatch, capsys):
+    from nodl_schema.models import NodlDocument
+
+    calls = []
+    result = describe_api.DescribeResult(doc=NodlDocument())
+
+    def describe_node(node_name, *, timeout_sec, options):
+        calls.append((node_name, timeout_sec, options))
+        return result
+
+    monkeypatch.setattr(describe_api, 'describe_node', describe_node)
+
+    assert DescribeVerb().main(args=_args(timeout=2.5, no_params=True, include_ros_infra=True)) == 0
+    assert yaml.safe_load(capsys.readouterr().out)['nodl_version'] == 2
+    assert calls[0][0:2] == (_TARGET_NODE, 2.5)
+    assert calls[0][2].include_parameters is False
+    assert calls[0][2].keep_hidden is True
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Implements the core of #70: a pure NoDL comparator plus `ros2 nodl conform` for checking an explicit NoDL file against a running node.

## Summary

- add `nodl_conformance.diff(expected, actual, node_fqn=...)` for strict semantic comparison of two loaded `NodlDocument` values
- return deterministic `Difference` values for missing, extra, mismatched, and unverifiable interfaces
- keep `nodl_conformance` ROS-free and dependent only on `nodl_schema`
- add runtime orchestration in `ros2nodl` for file loading, composition, live description, and diagnostics
- add `ros2 nodl conform NODE_NAME --file FILE [--timeout SEC]`
- expose `describe_node` as the single live-description path used by both Describe and Conform
- document the pure comparator and the Conform command

## Architecture

`nodl_conformance` owns only document-to-document comparison.
`ros2nodl` owns file loading, composition, live description, gap conversion, CLI behavior, and assertion formatting.
The Conform verb is a thin wrapper over the reusable runtime functions.

This PR intentionally does not add partial comparison scopes or CMake/launch-test integration.
The optional `ament_nodl_conformance` adapter remains follow-up work.

## Review guide

1. Start with `nodl_conformance/doc/overview.md`, the readable comparison contract, then review `nodl_conformance/nodl_conformance/_diff.py`, its implementation. `nodl_conformance/nodl_conformance/__init__.py` exposes the two-symbol public API.
2. Review `nodl_conformance/test/test_diff.py` alongside them. Most of the PR volume is exhaustive comparison coverage rather than production code.
3. Review `ros2nodl/ros2nodl/conformance.py` for the file-to-live boundary: load and compose, describe once, convert gaps, compare, and format one assertion.
4. Review `ros2nodl/ros2nodl/verb/conform.py` and `ros2nodl/test/test_conform_verb.py` for the thin CLI wrapper, exit behavior, and diagnostics.
5. Finish with `ros2nodl/ros2nodl/describe/__init__.py` and `ros2nodl/ros2nodl/verb/describe.py`, which make Describe and Conform share one live-description path.

The primary production path is 458 lines: 342 for the pure comparator, 70 for runtime orchestration, and 46 for the verb. The remaining change is primarily tests, package registration, and documentation.

## Verification

- rebased onto current `origin/main`
- ROS 2 Jazzy build passed for `nodl_schema`, `nodl_observe`, `nodl_conformance`, and `ros2nodl`
- `nodl_conformance`: 80 tests passed
- focused Conform, runtime conformance, and Describe API suite: 19 tests passed
- installed `ros2 nodl conform --help` exposed the expected command interface
- installed missing-file path returned exit code 1 with a clear diagnostic
- repository pre-commit checks passed
- combined Sphinx documentation built with warnings as errors
- `git diff --check` passed
