### PR TITLE
Make ROS 2 Basics C++ tutorial runnable

### DIFF
--- a/examples/nodl_tutorials/basics/CMakeLists.txt
+++ b/examples/nodl_tutorials/basics/CMakeLists.txt
@@ -19,6 +19,7 @@ install(TARGETS talker_cpp
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(tutorial_registration_tests test/test_registration.py)
+  ament_add_pytest_test(tutorial_runtime_tests test/test_runtime.py TIMEOUT 90)
 endif()
 
 ament_package()

--- a/examples/nodl_tutorials/basics/CMakeLists.txt
+++ b/examples/nodl_tutorials/basics/CMakeLists.txt
@@ -5,8 +5,16 @@ project(nodl_tutorial_basics)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_nodl REQUIRED)
+find_package(nodl_generator_cpp REQUIRED)
 
 ament_nodl_register(talker FILE nodl/talker.nodl.yaml)
+nodl_generate_cpp(talker nodl/talker_codegen.nodl.yaml)
+
+add_executable(talker_cpp cpp/talker.cpp)
+target_link_libraries(talker_cpp PRIVATE talker)
+
+install(TARGETS talker_cpp
+  DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)

--- a/examples/nodl_tutorials/basics/cpp/talker.cpp
+++ b/examples/nodl_tutorials/basics/cpp/talker.cpp
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "talker.hpp"  // NOLINT(build/include_subdir)
+
 #include <chrono>
 #include <cstddef>
 #include <memory>
 #include <string>
 
 #include "example_interfaces/msg/string.hpp"
-#include "nodl/talker_base.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 using std::chrono_literals::operator""ms;

--- a/examples/nodl_tutorials/basics/nodl/talker_codegen.nodl.yaml
+++ b/examples/nodl_tutorials/basics/nodl/talker_codegen.nodl.yaml
@@ -1,0 +1,6 @@
+---
+nodl_version: 2
+description: Generator composition for the C++ talker implementation.
+include:
+  - ref: nodl://rclcpp/node
+  - ref: local://talker.nodl.yaml

--- a/examples/nodl_tutorials/basics/package.xml
+++ b/examples/nodl_tutorials/basics/package.xml
@@ -22,6 +22,9 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_index_python</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>rmw_cyclonedds_cpp</test_depend>
+  <test_depend>ros2cli</test_depend>
+  <test_depend>ros2nodl</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/examples/nodl_tutorials/basics/package.xml
+++ b/examples/nodl_tutorials/basics/package.xml
@@ -9,6 +9,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_nodl</buildtool_depend>
+  <buildtool_depend>nodl_generator_cpp</buildtool_depend>
+
+  <build_depend>nodl_common_interfaces</build_depend>
+
+  <depend>example_interfaces</depend>
+  <depend>rclcpp</depend>
+
+  <exec_depend>demo_nodes_cpp</exec_depend>
+  <exec_depend>demo_nodes_py</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_index_python</test_depend>

--- a/examples/nodl_tutorials/basics/test/test_runtime.py
+++ b/examples/nodl_tutorials/basics/test/test_runtime.py
@@ -5,6 +5,7 @@
 import os
 import shutil
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
 
 from ament_index_python.packages import get_package_prefix, get_package_share_directory
@@ -31,10 +32,10 @@ def _contract():
     return share / 'nodl' / 'talker.nodl.yaml'
 
 
-def _run_conform(*node_arguments):
-    ros2 = shutil.which('ros2')
-    assert ros2 is not None
-
+# Each case owns one node and makes one CLI assertion, so a context manager keeps
+# the lifecycle clearer than a launch_testing description would.
+@contextmanager
+def _running_node(*node_arguments):
     node = subprocess.Popen(
         [_node_executable(), *node_arguments],
         env=_test_environment(),
@@ -42,6 +43,21 @@ def _run_conform(*node_arguments):
         stderr=subprocess.DEVNULL,
     )
     try:
+        yield
+    finally:
+        node.terminate()
+        try:
+            node.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            node.kill()
+            node.wait()
+
+
+def _run_conform(*node_arguments):
+    ros2 = shutil.which('ros2')
+    assert ros2 is not None
+
+    with _running_node(*node_arguments):
         return subprocess.run(
             [ros2, 'nodl', 'conform', NODE_NAME, '--file', _contract(), '--timeout', '10'],
             env=_test_environment(),
@@ -50,13 +66,6 @@ def _run_conform(*node_arguments):
             timeout=20,
             check=False,
         )
-    finally:
-        node.terminate()
-        try:
-            node.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            node.kill()
-            node.wait()
 
 
 def test_generated_node_conforms():

--- a/examples/nodl_tutorials/basics/test/test_runtime.py
+++ b/examples/nodl_tutorials/basics/test/test_runtime.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Exercise runtime conformance through the commands shown in the tutorial."""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from ament_index_python.packages import get_package_prefix, get_package_share_directory
+
+PACKAGE = 'nodl_tutorial_basics'
+NODE_NAME = '/talker'
+
+
+def _test_environment():
+    environment = os.environ.copy()
+    environment['ROS_DOMAIN_ID'] = str(os.getpid() % 100 + 100)
+    environment['ROS_AUTOMATIC_DISCOVERY_RANGE'] = 'LOCALHOST'
+    environment['RMW_IMPLEMENTATION'] = 'rmw_cyclonedds_cpp'
+    return environment
+
+
+def _node_executable():
+    prefix = Path(get_package_prefix(PACKAGE))
+    return prefix / 'lib' / PACKAGE / 'talker_cpp'
+
+
+def _contract():
+    share = Path(get_package_share_directory(PACKAGE))
+    return share / 'nodl' / 'talker.nodl.yaml'
+
+
+def _run_conform(*node_arguments):
+    ros2 = shutil.which('ros2')
+    assert ros2 is not None
+
+    node = subprocess.Popen(
+        [_node_executable(), *node_arguments],
+        env=_test_environment(),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        return subprocess.run(
+            [ros2, 'nodl', 'conform', NODE_NAME, '--file', _contract(), '--timeout', '10'],
+            env=_test_environment(),
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    finally:
+        node.terminate()
+        try:
+            node.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            node.kill()
+            node.wait()
+
+
+def test_generated_node_conforms():
+    result = _run_conform()
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == f'{NODE_NAME}: conforms'
+
+
+def test_remapped_topic_does_not_conform():
+    result = _run_conform('--ros-args', '-r', 'chatter:=chatter_regressed')
+
+    assert result.returncode != 0
+    assert "[missing] publishers '/chatter'" in result.stderr
+    assert "[extra] publishers '/chatter_regressed'" in result.stderr

--- a/nodl/doc/tutorials/basics.md
+++ b/nodl/doc/tutorials/basics.md
@@ -60,34 +60,41 @@ ros2 nodl validate examples/nodl_tutorials/basics/nodl/talker.nodl.yaml
 The contract owns the publisher declaration. The timer, counter, log message, and `Hello World` contents remain
 application behavior.
 
-## 3. Generate a binding
+## 3. Register and generate in the package build
 
-Use the same NoDL file regardless of language.
+Keep NoDL validation, registration, generation, and installation in the package build.
+Use the same NoDL contract regardless of language.
 
 ::::{tabs}
 :::{group-tab} C++
+
+Add the contract and C++ generator to the package's `CMakeLists.txt`:
+
+```{literalinclude} ../../../examples/nodl_tutorials/basics/CMakeLists.txt
+:language: cmake
+:start-at: find_package(ament_nodl REQUIRED)
+:end-at: DESTINATION lib/${PROJECT_NAME})
+```
+
+`ament_nodl_register()` validates the public contract and registers it in the ament index.
+`nodl_generate_cpp()` generates the C++ base and rebuilds it when the contract changes.
+
+Build and source the package:
 
 ```bash
 colcon build --packages-select nodl_tutorial_basics
 source install/setup.bash
 ```
 
-The package uses `nodl_generate_cpp()` to generate a C++ base with the declared publisher as `pub_chatter_`.
+The generated C++ base exposes the declared publisher as `pub_chatter_`.
 
 :::
 
 :::{group-tab} Python
 
 **Warning: Python generation is not yet implemented.**
-The Python commands and generated API in sections 3 through 5 show the intended product experience.
-
-```bash
-ros2 nodl generate \
-  examples/nodl_tutorials/basics/nodl/talker.nodl.yaml \
-  --language python --output generated/python_talker
-```
-
-The generated Python base exposes the same publisher as `pub_chatter`.
+The Python examples in sections 4 and 5 are illustrative and cannot be run yet.
+Python generation should be integrated into the package's ament build when support becomes available.
 
 :::
 ::::

--- a/nodl/doc/tutorials/basics.md
+++ b/nodl/doc/tutorials/basics.md
@@ -92,10 +92,10 @@ The generated C++ base exposes the declared publisher as `pub_chatter_`.
 
 :::{group-tab} Python
 
-:::{warning}
+```{warning}
 Python generation is not yet implemented.
 The CMake below shows the intended package-build integration and cannot be run yet.
-:::
+```
 
 ```cmake
 find_package(ament_nodl REQUIRED)
@@ -128,10 +128,10 @@ Subclass the generated interface and keep the timer and message behavior in norm
 
 :::{group-tab} Python
 
-:::{warning}
+```{warning}
 Python generation is not yet implemented.
 The code below shows the intended generated API and cannot be run yet.
-:::
+```
 
 ```{literalinclude} ../../../examples/nodl_tutorials/basics/python/talker.py
 :language: python
@@ -161,13 +161,12 @@ ros2 nodl conform /talker \
 
 :::{group-tab} Python
 
-:::{warning}
+```{warning}
 Python generation is not yet implemented.
 The commands below show the intended workflow and cannot be run yet.
-:::
+```
 
 ```bash
-colcon build --packages-select nodl_tutorial_python_talker
 # Terminal 1
 ros2 run nodl_tutorial_python_talker talker
 # Terminal 2

--- a/nodl/doc/tutorials/basics.md
+++ b/nodl/doc/tutorials/basics.md
@@ -94,8 +94,21 @@ The generated C++ base exposes the declared publisher as `pub_chatter_`.
 
 :::{warning}
 Python generation is not yet implemented.
-It should be integrated into the package's ament build when support becomes available.
+The CMake below shows the intended package-build integration and cannot be run yet.
 :::
+
+```cmake
+find_package(ament_nodl REQUIRED)
+find_package(nodl_generator_py REQUIRED)
+
+ament_nodl_register(talker FILE nodl/talker.nodl.yaml)
+nodl_generate_py(talker nodl/talker.nodl.yaml)
+```
+
+```bash
+colcon build --packages-select nodl_tutorial_python_talker
+source install/setup.bash
+```
 
 :::
 ::::

--- a/nodl/doc/tutorials/basics.md
+++ b/nodl/doc/tutorials/basics.md
@@ -7,12 +7,6 @@ Application behavior remains ordinary ROS code.
 
 Choose C++ or Python in any language tab. The browser remembers that choice for the other grouped tabs on this page.
 
-:::{note} Capability status
-`describe`, `validate`, and the underlying C++ generator work on NoDL `main`.
-The unified generation command, Python generation, generated APIs, and conformance flow below show the intended
-product experience and are not implemented on `main` yet.
-:::
-
 ## 1. Describe the existing interface
 
 Start one upstream talker and describe it from a second terminal.
@@ -68,27 +62,24 @@ application behavior.
 
 ## 3. Generate a binding
 
-:::{warning} Draft workflow: not yet implemented
-The unified commands and generated APIs in sections 3 through 5 show the intended product experience.
-The underlying C++ generator exists, but this complete cross-language workflow is not available on NoDL `main`.
-:::
-
 Use the same NoDL file regardless of language.
 
 ::::{tabs}
 :::{group-tab} C++
 
 ```bash
-ros2 nodl generate \
-  examples/nodl_tutorials/basics/nodl/talker.nodl.yaml \
-  --language cpp --output generated/cpp_talker
+colcon build --packages-select nodl_tutorial_basics
+source install/setup.bash
 ```
 
-The generated C++ base exposes the declared publisher as `pub_chatter_`.
+The package uses `nodl_generate_cpp()` to generate a C++ base with the declared publisher as `pub_chatter_`.
 
 :::
 
 :::{group-tab} Python
+
+**Warning: Python generation is not yet implemented.**
+The Python commands and generated API in sections 3 through 5 show the intended product experience.
 
 ```bash
 ros2 nodl generate \
@@ -127,18 +118,15 @@ NoDL does not generate the timer period, counter, message contents, or logging i
 
 ## 5. Test a running implementation for conformance
 
-:::{warning} Draft command: not yet implemented
-`ros2 nodl conform` is proposed tutorial UX. NoDL `main` does not provide this command yet.
-:::
-
-Build and start the selected implementation, then compare its observed interface with the shared contract.
+Start the selected implementation, then compare its observed interface with the shared contract.
 
 ::::{tabs}
 :::{group-tab} C++
 
 ```bash
-colcon build --packages-select nodl_tutorial_cpp_talker
-ros2 run nodl_tutorial_cpp_talker talker
+# Terminal 1
+ros2 run nodl_tutorial_basics talker_cpp
+# Terminal 2
 ros2 nodl conform /talker \
   --file examples/nodl_tutorials/basics/nodl/talker.nodl.yaml
 ```
@@ -149,7 +137,9 @@ ros2 nodl conform /talker \
 
 ```bash
 colcon build --packages-select nodl_tutorial_python_talker
+# Terminal 1
 ros2 run nodl_tutorial_python_talker talker
+# Terminal 2
 ros2 nodl conform /talker \
   --file examples/nodl_tutorials/basics/nodl/talker.nodl.yaml
 ```
@@ -157,19 +147,25 @@ ros2 nodl conform /talker \
 :::
 ::::
 
-For an intentional QoS regression, first ensure that the generated publisher enables ROS QoS overrides.
-Then restart the talker with the ROS parameter
-`qos_overrides./chatter.publisher.reliability:=best_effort`, leaving the NoDL contract unchanged.
-Conformance should identify:
+The conforming result is:
 
 ```text
-[mismatch] publishers '/chatter'.qos.reliability
-  expected: RELIABLE
-  observed: BEST_EFFORT
+/talker: conforms
 ```
 
-Restore `RELIABLE` before the next run. Topic-name, durability, history, and depth variants follow the same pattern.
+For an intentional regression, remap the generated publisher and leave the NoDL contract unchanged:
 
-This regression is a target acceptance case, not an executable fixture in this PR.
-Before the command is presented as runnable, CI must start the generated node, verify its observed publisher QoS, and
-assert the expected conformance failure on each supported ROS and RMW combination.
+```bash
+# Terminal 1
+ros2 run nodl_tutorial_basics talker_cpp --ros-args -r chatter:=chatter_regressed
+# Terminal 2
+ros2 nodl conform /talker \
+  --file examples/nodl_tutorials/basics/nodl/talker.nodl.yaml
+```
+
+```text
+[missing] publishers '/chatter': expected type 'example_interfaces/msg/String' was not observed
+[extra] publishers '/chatter_regressed': observed undeclared type 'example_interfaces/msg/String'
+```
+
+Restart the talker without the remapping to restore conformance.

--- a/nodl/doc/tutorials/basics.md
+++ b/nodl/doc/tutorials/basics.md
@@ -92,9 +92,10 @@ The generated C++ base exposes the declared publisher as `pub_chatter_`.
 
 :::{group-tab} Python
 
-**Warning: Python generation is not yet implemented.**
-The Python examples in sections 4 and 5 are illustrative and cannot be run yet.
-Python generation should be integrated into the package's ament build when support becomes available.
+:::{warning}
+Python generation is not yet implemented.
+It should be integrated into the package's ament build when support becomes available.
+:::
 
 :::
 ::::
@@ -113,6 +114,11 @@ Subclass the generated interface and keep the timer and message behavior in norm
 :::
 
 :::{group-tab} Python
+
+:::{warning}
+Python generation is not yet implemented.
+The code below shows the intended generated API and cannot be run yet.
+:::
 
 ```{literalinclude} ../../../examples/nodl_tutorials/basics/python/talker.py
 :language: python
@@ -141,6 +147,11 @@ ros2 nodl conform /talker \
 :::
 
 :::{group-tab} Python
+
+:::{warning}
+Python generation is not yet implemented.
+The commands below show the intended workflow and cannot be run yet.
+:::
 
 ```bash
 colcon build --packages-select nodl_tutorial_python_talker


### PR DESCRIPTION
## Summary
- make the ROS 2 Basics C++ talker runnable through its package's CMake/ament build
- make `ament_nodl_register()` and `nodl_generate_cpp()` the canonical workflow instead of standalone generation
- replace draft C++ instructions with tested build, run, conformance, and topic-regression commands
- retain the intended future Python ament integration and generated API under explicit per-tab warnings
- add runtime conformance tests for both the valid talker and the topic-remapping regression

## Verification
- repository pre-commit hooks passed for every changed file
- strict Sphinx documentation build passed with warnings as errors
- `nodl_tutorial_basics` built on ROS 2 Jazzy
- all four `nodl_tutorial_basics` package tests passed on ROS 2 Jazzy, including both runtime cases
- the existing tutorial CI matrix runs this package on Humble, Jazzy, Kilted, Lyrical, and Rolling

## Current limitation
- Python generation is not implemented; the Python tabs explicitly mark their examples as the intended future workflow
