### PR TITLE
release: Prepare 2.0.0 release

### DIFF
--- a/ament_nodl/CHANGELOG.rst
+++ b/ament_nodl/CHANGELOG.rst
@@ -1,0 +1,19 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package ament_nodl
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* feat: ament_nodl_register rewrite local refs to ament index refs (`#111 <https://github.com/ros-tooling/nodl/issues/111>`_)
+* feat: remove nodl_schema CLI entrypoint, always use ros2nodl for CLIs (`#112 <https://github.com/ros-tooling/nodl/issues/112>`_)
+* feat: rename ament_nodl_register_node to ament_nodl_register (`#106 <https://github.com/ros-tooling/nodl/issues/106>`_)
+* Include: groundwork with ament_index only (`#97 <https://github.com/ros-tooling/nodl/issues/97>`_)
+* Per-package documentation (`#87 <https://github.com/ros-tooling/nodl/issues/87>`_)
+* Add ament_nodl with the register_node CMake macro (`#75 <https://github.com/ros-tooling/nodl/issues/75>`_)
+* Contributors: Emerson Knapp
+
+0.3.1 (2020-11-19)
+------------------
+
+0.1.0 (2020-06-01)
+------------------

--- a/ament_nodl/CHANGELOG.rst
+++ b/ament_nodl/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ament_nodl
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.0.0 (2026-09-01)
+------------------
 * feat: ament_nodl_register rewrite local refs to ament index refs (`#111 <https://github.com/ros-tooling/nodl/issues/111>`_)
 * feat: remove nodl_schema CLI entrypoint, always use ros2nodl for CLIs (`#112 <https://github.com/ros-tooling/nodl/issues/112>`_)
 * feat: rename ament_nodl_register_node to ament_nodl_register (`#106 <https://github.com/ros-tooling/nodl/issues/106>`_)

--- a/ament_nodl/package.xml
+++ b/ament_nodl/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ament_nodl</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>CMake macros for registering NoDL documents with the ament index.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>

--- a/ament_nodl/package.xml
+++ b/ament_nodl/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ament_nodl</name>
-  <version>0.1.0</version>
+  <version>0.0.0</version>
   <description>CMake macros for registering NoDL documents with the ament index.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>

--- a/examples/nodl_tutorials/basics/package.xml
+++ b/examples/nodl_tutorials/basics/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nodl_tutorial_basics</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>Validated and registered NoDL documents used by the ROS 2 basics tutorial.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>

--- a/nodl/CHANGELOG.rst
+++ b/nodl/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package nodl
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.0.0 (2026-09-01)
+------------------
 * Add NoDL conformance comparison and conform verb (`#115 <https://github.com/ros-tooling/nodl/issues/115>`_)
 * Add ROS 2 basics tutorial (`#114 <https://github.com/ros-tooling/nodl/issues/114>`_)
 * update documentation (`#141 <https://github.com/ros-tooling/nodl/issues/141>`_)

--- a/nodl/CHANGELOG.rst
+++ b/nodl/CHANGELOG.rst
@@ -1,0 +1,28 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package nodl
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Add NoDL conformance comparison and conform verb (`#115 <https://github.com/ros-tooling/nodl/issues/115>`_)
+* Add ROS 2 basics tutorial (`#114 <https://github.com/ros-tooling/nodl/issues/114>`_)
+* update documentation (`#141 <https://github.com/ros-tooling/nodl/issues/141>`_)
+* CMake integration for `nodl_generate_cpp` (`#139 <https://github.com/ros-tooling/nodl/issues/139>`_)
+* Add Why NoDL documentation (`#113 <https://github.com/ros-tooling/nodl/issues/113>`_)
+* doc: Document nodl_docgen package and usage (`#133 <https://github.com/ros-tooling/nodl/issues/133>`_)
+* Add nodl_generator_cpp (Generation only - no Cmake) (`#104 <https://github.com/ros-tooling/nodl/issues/104>`_)
+* Add byte-array parameter type to NoDL schema (`#95 <https://github.com/ros-tooling/nodl/issues/95>`_)
+* Add ros2 nodl describe: rosgraph_msgs/Node -> NoDL document (`#53 <https://github.com/ros-tooling/nodl/issues/53>`_) (`#89 <https://github.com/ros-tooling/nodl/issues/89>`_)
+* Per-package documentation (`#87 <https://github.com/ros-tooling/nodl/issues/87>`_)
+* feat: Observe a running node as rosgraph_msgs/Node via ros2 nodl describe (`#83 <https://github.com/ros-tooling/nodl/issues/83>`_)
+* Docs styling pass with sphinx-immaterial (`#81 <https://github.com/ros-tooling/nodl/issues/81>`_)
+* Scaffold NoDL documentation via ReadTheDocs (`#79 <https://github.com/ros-tooling/nodl/issues/79>`_)
+* Add ament_nodl with the register_node CMake macro (`#75 <https://github.com/ros-tooling/nodl/issues/75>`_)
+* create new nodl v2 schema within a new package named nodl (`#55 <https://github.com/ros-tooling/nodl/issues/55>`_)
+* Contributors: Alistair English, Emerson Knapp, Luke Sy
+
+0.3.1 (2020-11-19)
+------------------
+
+0.1.0 (2020-06-01)
+------------------

--- a/nodl/package.xml
+++ b/nodl/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nodl</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>ROS 2 Node Definition Language (NoDL) metapackage.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>

--- a/nodl_common_interfaces/CHANGELOG.rst
+++ b/nodl_common_interfaces/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package nodl_common_interfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.0.0 (2026-09-01)
+------------------
 * update documentation (`#141 <https://github.com/ros-tooling/nodl/issues/141>`_)
 * CMake integration for `nodl_generate_cpp` (`#139 <https://github.com/ros-tooling/nodl/issues/139>`_)
 * Contributors: Alistair English

--- a/nodl_common_interfaces/CHANGELOG.rst
+++ b/nodl_common_interfaces/CHANGELOG.rst
@@ -1,0 +1,15 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package nodl_common_interfaces
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* update documentation (`#141 <https://github.com/ros-tooling/nodl/issues/141>`_)
+* CMake integration for `nodl_generate_cpp` (`#139 <https://github.com/ros-tooling/nodl/issues/139>`_)
+* Contributors: Alistair English
+
+0.3.1 (2020-11-19)
+------------------
+
+0.1.0 (2020-06-01)
+------------------

--- a/nodl_common_interfaces/package.xml
+++ b/nodl_common_interfaces/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nodl_common_interfaces</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>
     NoDL interface descriptions for standard ROS 2 node base classes (rclcpp::Node, rclcpp_lifecycle::LifecycleNode).
 

--- a/nodl_conformance/CHANGELOG.rst
+++ b/nodl_conformance/CHANGELOG.rst
@@ -1,0 +1,14 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package nodl_conformance
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Add NoDL conformance comparison and conform verb (`#115 <https://github.com/ros-tooling/nodl/issues/115>`_)
+* Contributors: Luke Sy
+
+0.3.1 (2020-11-19)
+------------------
+
+0.1.0 (2020-06-01)
+------------------

--- a/nodl_conformance/CHANGELOG.rst
+++ b/nodl_conformance/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package nodl_conformance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.0.0 (2026-09-01)
+------------------
 * Add NoDL conformance comparison and conform verb (`#115 <https://github.com/ros-tooling/nodl/issues/115>`_)
 * Contributors: Luke Sy
 

--- a/nodl_conformance/package.xml
+++ b/nodl_conformance/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nodl_conformance</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>Pure semantic comparison for NoDL node interface documents.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>

--- a/nodl_conformance/setup.py
+++ b/nodl_conformance/setup.py
@@ -6,7 +6,7 @@ package_name = 'nodl_conformance'
 
 setup(
     name=package_name,
-    version='0.0.0',
+    version='2.0.0',
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),

--- a/nodl_docgen/CHANGELOG.rst
+++ b/nodl_docgen/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package nodl_docgen
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.0.0 (2026-09-01)
+------------------
 * doc: Document nodl_docgen package and usage (`#133 <https://github.com/ros-tooling/nodl/issues/133>`_)
 * feat: Add sphinx directive for invoking nodl_docgen (`#131 <https://github.com/ros-tooling/nodl/issues/131>`_)
 * feat: add nodl_docgen package with a pure NoDL summary core (`#127 <https://github.com/ros-tooling/nodl/issues/127>`_)

--- a/nodl_docgen/CHANGELOG.rst
+++ b/nodl_docgen/CHANGELOG.rst
@@ -1,0 +1,16 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package nodl_docgen
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* doc: Document nodl_docgen package and usage (`#133 <https://github.com/ros-tooling/nodl/issues/133>`_)
+* feat: Add sphinx directive for invoking nodl_docgen (`#131 <https://github.com/ros-tooling/nodl/issues/131>`_)
+* feat: add nodl_docgen package with a pure NoDL summary core (`#127 <https://github.com/ros-tooling/nodl/issues/127>`_)
+* Contributors: Emerson Knapp
+
+0.3.1 (2020-11-19)
+------------------
+
+0.1.0 (2020-06-01)
+------------------

--- a/nodl_docgen/package.xml
+++ b/nodl_docgen/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nodl_docgen</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>Documentation generation and Sphinx rendering of ROS 2 Node Definition Language (NoDL) documents.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>

--- a/nodl_docgen/setup.py
+++ b/nodl_docgen/setup.py
@@ -6,7 +6,7 @@ package_name = 'nodl_docgen'
 
 setup(
     name=package_name,
-    version='0.0.0',
+    version='2.0.0',
     packages=[package_name],
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),

--- a/nodl_generator_cpp/CHANGELOG.rst
+++ b/nodl_generator_cpp/CHANGELOG.rst
@@ -1,0 +1,18 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package nodl_generator_cpp
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* update documentation (`#141 <https://github.com/ros-tooling/nodl/issues/141>`_)
+* CMake integration for `nodl_generate_cpp` (`#139 <https://github.com/ros-tooling/nodl/issues/139>`_)
+* Add `--cmake-deps` CLI mode for configure-time dependency extraction (`#138 <https://github.com/ros-tooling/nodl/issues/138>`_)
+* add path to IncludedDocument in DocumentTree for provenance (`#120 <https://github.com/ros-tooling/nodl/issues/120>`_)
+* Add nodl_generator_cpp (Generation only - no Cmake) (`#104 <https://github.com/ros-tooling/nodl/issues/104>`_)
+* Contributors: Alistair English
+
+0.3.1 (2020-11-19)
+------------------
+
+0.1.0 (2020-06-01)
+------------------

--- a/nodl_generator_cpp/CHANGELOG.rst
+++ b/nodl_generator_cpp/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package nodl_generator_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.0.0 (2026-09-01)
+------------------
 * update documentation (`#141 <https://github.com/ros-tooling/nodl/issues/141>`_)
 * CMake integration for `nodl_generate_cpp` (`#139 <https://github.com/ros-tooling/nodl/issues/139>`_)
 * Add `--cmake-deps` CLI mode for configure-time dependency extraction (`#138 <https://github.com/ros-tooling/nodl/issues/138>`_)

--- a/nodl_generator_cpp/package.xml
+++ b/nodl_generator_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nodl_generator_cpp</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>Generate an rclcpp base-node class from a NoDL document.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>

--- a/nodl_observe/CHANGELOG.rst
+++ b/nodl_observe/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package nodl_observe
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.0.0 (2026-09-01)
+------------------
 * Per-package documentation (`#87 <https://github.com/ros-tooling/nodl/issues/87>`_)
 * feat: Observe a running node as rosgraph_msgs/Node via ros2 nodl describe (`#83 <https://github.com/ros-tooling/nodl/issues/83>`_)
 * Contributors: Emerson Knapp, Luke Sy

--- a/nodl_observe/CHANGELOG.rst
+++ b/nodl_observe/CHANGELOG.rst
@@ -1,0 +1,15 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package nodl_observe
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Per-package documentation (`#87 <https://github.com/ros-tooling/nodl/issues/87>`_)
+* feat: Observe a running node as rosgraph_msgs/Node via ros2 nodl describe (`#83 <https://github.com/ros-tooling/nodl/issues/83>`_)
+* Contributors: Emerson Knapp, Luke Sy
+
+0.3.1 (2020-11-19)
+------------------
+
+0.1.0 (2020-06-01)
+------------------

--- a/nodl_observe/package.xml
+++ b/nodl_observe/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nodl_observe</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>Observe a running ROS node and produce its runtime description as a rosgraph_msgs/Node message.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>

--- a/nodl_schema/CHANGELOG.rst
+++ b/nodl_schema/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package nodl_schema
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.0.0 (2026-09-01)
+------------------
 * add path to IncludedDocument in DocumentTree for provenance (`#120 <https://github.com/ros-tooling/nodl/issues/120>`_)
 * feat: ament_nodl_register rewrite local refs to ament index refs (`#111 <https://github.com/ros-tooling/nodl/issues/111>`_)
 * feat: remove nodl_schema CLI entrypoint, always use ros2nodl for CLIs (`#112 <https://github.com/ros-tooling/nodl/issues/112>`_)

--- a/nodl_schema/CHANGELOG.rst
+++ b/nodl_schema/CHANGELOG.rst
@@ -1,0 +1,28 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package nodl_schema
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* add path to IncludedDocument in DocumentTree for provenance (`#120 <https://github.com/ros-tooling/nodl/issues/120>`_)
+* feat: ament_nodl_register rewrite local refs to ament index refs (`#111 <https://github.com/ros-tooling/nodl/issues/111>`_)
+* feat: remove nodl_schema CLI entrypoint, always use ros2nodl for CLIs (`#112 <https://github.com/ros-tooling/nodl/issues/112>`_)
+* feat: Add local reference resolver (`#105 <https://github.com/ros-tooling/nodl/issues/105>`_)
+* feat: Include resolvers always return a Path (`#110 <https://github.com/ros-tooling/nodl/issues/110>`_)
+* test: add pyright checker for nodl_schema and ros2nodl (`#109 <https://github.com/ros-tooling/nodl/issues/109>`_)
+* feat: rename ament_nodl_register_node to ament_nodl_register (`#106 <https://github.com/ros-tooling/nodl/issues/106>`_)
+* Add `codgen` key to schema (`#102 <https://github.com/ros-tooling/nodl/issues/102>`_)
+* Expose the include tree from load_nodl (`#101 <https://github.com/ros-tooling/nodl/issues/101>`_)
+* Include: groundwork with ament_index only (`#97 <https://github.com/ros-tooling/nodl/issues/97>`_)
+* Add byte-array parameter type to NoDL schema (`#95 <https://github.com/ros-tooling/nodl/issues/95>`_)
+* Per-package documentation (`#87 <https://github.com/ros-tooling/nodl/issues/87>`_)
+* Docs styling pass with sphinx-immaterial (`#81 <https://github.com/ros-tooling/nodl/issues/81>`_)
+* Add ament_nodl with the register_node CMake macro (`#75 <https://github.com/ros-tooling/nodl/issues/75>`_)
+* create new nodl v2 schema within a new package named nodl (`#55 <https://github.com/ros-tooling/nodl/issues/55>`_)
+* Contributors: Alistair English, Emerson Knapp, Luke Sy
+
+0.3.1 (2020-11-19)
+------------------
+
+0.1.0 (2020-06-01)
+------------------

--- a/nodl_schema/package.xml
+++ b/nodl_schema/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nodl_schema</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>ROS 2 Node Definition Language (NoDL) schema and validation.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>

--- a/nodl_schema/setup.py
+++ b/nodl_schema/setup.py
@@ -6,7 +6,7 @@ package_name = 'nodl_schema'
 
 setup(
     name=package_name,
-    version='0.0.0',
+    version='2.0.0',
     packages=[package_name],
     package_data={package_name: ['schemas/*.yaml']},
     data_files=[

--- a/ros2nodl/CHANGELOG.rst
+++ b/ros2nodl/CHANGELOG.rst
@@ -1,0 +1,62 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package ros2nodl
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Add NoDL conformance comparison and conform verb (`#115 <https://github.com/ros-tooling/nodl/issues/115>`_)
+* feat: ament_nodl_register rewrite local refs to ament index refs (`#111 <https://github.com/ros-tooling/nodl/issues/111>`_)
+* feat: remove nodl_schema CLI entrypoint, always use ros2nodl for CLIs (`#112 <https://github.com/ros-tooling/nodl/issues/112>`_)
+* feat: Include resolvers always return a Path (`#110 <https://github.com/ros-tooling/nodl/issues/110>`_)
+* test: add pyright checker for nodl_schema and ros2nodl (`#109 <https://github.com/ros-tooling/nodl/issues/109>`_)
+* Include: groundwork with ament_index only (`#97 <https://github.com/ros-tooling/nodl/issues/97>`_)
+* Add byte-array parameter type to NoDL schema (`#95 <https://github.com/ros-tooling/nodl/issues/95>`_)
+* Add ros2 nodl describe: rosgraph_msgs/Node -> NoDL document (`#53 <https://github.com/ros-tooling/nodl/issues/53>`_) (`#89 <https://github.com/ros-tooling/nodl/issues/89>`_)
+* Per-package documentation (`#87 <https://github.com/ros-tooling/nodl/issues/87>`_)
+* feat: Observe a running node as rosgraph_msgs/Node via ros2 nodl describe (`#83 <https://github.com/ros-tooling/nodl/issues/83>`_)
+* create new nodl v2 schema within a new package named nodl (`#55 <https://github.com/ros-tooling/nodl/issues/55>`_)
+* start fresh (`#54 <https://github.com/ros-tooling/nodl/issues/54>`_)
+* Using underscore names in `setup.cfg` (`#42 <https://github.com/ros-tooling/nodl/issues/42>`_)
+* Contributors: Abrar Rahman Protyasha, Alistair English, Emerson Knapp, Luke Sy
+
+0.3.1 (2020-11-19)
+------------------
+* Merge pull request `#40 <https://github.com/ros-tooling/nodl/issues/40>`_ from Arnatious/bump_version
+  Bump version to 0.3.1
+* 0.3.1
+* Merge pull request `#39 <https://github.com/ros-tooling/nodl/issues/39>`_ from ubuntu-robotics/foxy_merge
+  merge foxy-devel changes back into master
+* merge foxy-devel changes back into master
+* Merge pull request `#35 <https://github.com/ros-tooling/nodl/issues/35>`_ from ubuntu-robotics/relicense-apache
+  relicense project as Apache 2.0
+* relicense project as Apache 2.0
+* Merge pull request `#21 <https://github.com/ros-tooling/nodl/issues/21>`_ from Arnatious/add_direction
+  add role field, replacing bool pairs
+* add directionality flag
+* Merge pull request `#23 <https://github.com/ros-tooling/nodl/issues/23>`_ from Arnatious/remove_qos
+  strip qos from nodl_python
+* Merge pull request `#22 <https://github.com/ros-tooling/nodl/issues/22>`_ from Arnatious/codecov
+  test all packages and use codecov
+* strip qos from nodl_python
+* add codecov and rewrite ci script
+* Contributors: Ted Kern
+
+0.1.0 (2020-06-01)
+------------------
+* Merge pull request `#19 <https://github.com/ros-tooling/nodl/issues/19>`_ from kyrofa/bugfix/argcomplete_dep
+  Depend on python3-argcomplete
+* Depend on python3-argcomplete
+  `argcomplete` is not a valid rosdep dependency.
+* Merge pull request `#18 <https://github.com/ros-tooling/nodl/issues/18>`_ from ubuntu-robotics/bugfix/remove_buildtool_depend
+  Remove buildtool_depend on nodl_python
+* Remove buildtool_depend on nodl_python
+  It's not a valid rosdep dependency and is unnecessary anyway.
+* Update CHANGELOGs and package.xmls for 0.1.0
+* Update CHANGELOGs and package.xmls for 0.1.0
+* Merge pull request `#17 <https://github.com/ros-tooling/nodl/issues/17>`_ from Arnatious/update_readmes_and_tests
+  Update readmes and tests
+* fix license files, small print error in validate, readmes
+* Merge pull request `#9 <https://github.com/ros-tooling/nodl/issues/9>`_ from Arnatious/cli
+  add CLI with `show` and `validate` verbs
+* add show and validate verbs
+* Contributors: Kyle Fazzari, Ted Kern

--- a/ros2nodl/CHANGELOG.rst
+++ b/ros2nodl/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ros2nodl
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+2.0.0 (2026-09-01)
+------------------
 * Add NoDL conformance comparison and conform verb (`#115 <https://github.com/ros-tooling/nodl/issues/115>`_)
 * feat: ament_nodl_register rewrite local refs to ament index refs (`#111 <https://github.com/ros-tooling/nodl/issues/111>`_)
 * feat: remove nodl_schema CLI entrypoint, always use ros2nodl for CLIs (`#112 <https://github.com/ros-tooling/nodl/issues/112>`_)

--- a/ros2nodl/package.xml
+++ b/ros2nodl/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2nodl</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>ros2cli command entrypoint for NoDL.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>

--- a/ros2nodl/setup.py
+++ b/ros2nodl/setup.py
@@ -6,7 +6,7 @@ package_name = 'ros2nodl'
 
 setup(
     name=package_name,
-    version='0.0.0',
+    version='2.0.0',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),

--- a/test_ament_nodl/package.xml
+++ b/test_ament_nodl/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>test_ament_nodl</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>Integration tests for the ament_nodl CMake macros.</description>
   <maintainer email="rosgraph-wg@googlegroups.com">ROSGraph Working Group</maintainer>
   <license>Apache-2.0</license>

--- a/test_nodl_generator_cpp/package.xml
+++ b/test_nodl_generator_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>test_nodl_generator_cpp</name>
-  <version>0.0.0</version>
+  <version>2.0.0</version>
   <description>
     Integration tests for nodl_generator_cpp.
     Exercises the nodl_generate_cpp() CMake macro end-to-end:


### PR DESCRIPTION
Update CHANGELOGs, bump version to 2.0.0

Considering this a "preview" release of NoDL v2, with the understanding that it won't be complete right away, but we can start validating buildfarm builds, and using what features do exist so far.

