### PR TITLE
build: disable pip-based test dependencies by default for buildfarm, enabled in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,10 @@ jobs:
     needs: changes
     if: always()
     runs-on: ubuntu-latest
-    # mcap-ros2-support is a pip rosdep; PEP 668 (Python >=3.11) needs this.
     env:
+      # Enable pip-originated test dependencies to get the full test suite
+      ENABLE_PIP_TEST_DEPENDS: 1
+      # PEP 668 (Python >=3.11) needs this for `pip install` (from `rosdep install`) without a venv
       PIP_BREAK_SYSTEM_PACKAGES: 1
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ pre-commit install --hook-type prepare-commit-msg
 ```
 
 The `prepare-commit-msg` hook will automatically add the `Signed-off-by` line to your commits. If you prefer to sign off manually, use `git commit -s`.
+
+### Pip dependencies for full test suite
+
+The packages in this repository use a few package only available from `pip` as `test_depend`s.
+
+For the buildfarm environment, these dependencies and tests are disabled, because a package may not be packaged into a `deb`/`rpm` against dependencies from another package manager (`pip`).
+
+To install all dependencies and run the full test suite, export environment variable `ENABLE_PIP_TEST_DEPENDS=1` - which the GitHub Action CI for this repo does.

--- a/nodl_docgen/package.xml
+++ b/nodl_docgen/package.xml
@@ -14,7 +14,7 @@
   <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>python3-pytest</test_depend>
-  <test_depend>python3-pyright-pip</test_depend>
+  <test_depend condition="$ENABLE_PIP_TEST_DEPENDS == 1">python3-pyright-pip</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/nodl_docgen/test/test_pyright.py
+++ b/nodl_docgen/test/test_pyright.py
@@ -2,18 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """Static type checking with pyright."""
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
-pytest.importorskip('pyright')
+# The importable package source lives one level up from this test directory.
+_SOURCE_DIR = Path(__file__).resolve().parent.parent
 
 
+@pytest.mark.skipif(shutil.which('pyright') is None, reason='pyright is not installed')
 def test_pyright():
-    # The importable package source lives one level up from this test directory.
-    _SOURCE_DIR = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         ['pyright', str(_SOURCE_DIR)],
         stdout=subprocess.PIPE,

--- a/nodl_docgen/test/test_pyright.py
+++ b/nodl_docgen/test/test_pyright.py
@@ -6,11 +6,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-# The importable package source lives one level up from this test directory.
-_SOURCE_DIR = Path(__file__).resolve().parent.parent
+import pytest
+
+pytest.importorskip('pyright')
 
 
 def test_pyright():
+    # The importable package source lives one level up from this test directory.
+    _SOURCE_DIR = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         ['pyright', str(_SOURCE_DIR)],
         stdout=subprocess.PIPE,

--- a/nodl_observe/CMakeLists.txt
+++ b/nodl_observe/CMakeLists.txt
@@ -78,12 +78,20 @@ if(BUILD_TESTING)
   # rcl/test/CMakeLists.txt). ctest -> test_observe_integration__<rmw>.
   find_package(ament_cmake_pytest REQUIRED)
   find_package(rmw_implementation_cmake REQUIRED)
+
+  # The integration test needs `mcap-ros2-support` test dependency.
+  set(_observe_integration_skip "")
+  if(NOT "$ENV{ENABLE_PIP_TEST_DEPENDS}" STREQUAL "1")
+    set(_observe_integration_skip "SKIP_TEST")
+  endif()
+
   macro(observe_integration_test_for_rmw)
     ament_add_pytest_test(
       "test_observe_integration${target_suffix}"
       test/test_observe_integration.py
       ENV RMW_IMPLEMENTATION=${rmw_implementation}
       TIMEOUT 180
+      ${_observe_integration_skip}
     )
   endmacro()
 

--- a/nodl_observe/package.xml
+++ b/nodl_observe/package.xml
@@ -33,7 +33,7 @@
   <test_depend>rosidl_runtime_py</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>example_interfaces</test_depend>
-  <test_depend>mcap-ros2-support</test_depend>
+  <test_depend condition="$ENABLE_PIP_TEST_DEPENDS == 1">mcap-ros2-support</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/nodl_schema/package.xml
+++ b/nodl_schema/package.xml
@@ -16,7 +16,7 @@
   <exec_depend>python3-yaml</exec_depend>
 
   <test_depend>python3-pytest</test_depend>
-  <test_depend>python3-pyright-pip</test_depend>
+  <test_depend condition="$ENABLE_PIP_TEST_DEPENDS == 1">python3-pyright-pip</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/nodl_schema/test/test_pyright.py
+++ b/nodl_schema/test/test_pyright.py
@@ -2,18 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """Static type checking with pyright."""
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
-pytest.importorskip('pyright')
+# The importable package source lives one level up from this test directory.
+_SOURCE_DIR = Path(__file__).resolve().parent.parent
 
 
+@pytest.mark.skipif(shutil.which('pyright') is None, reason='pyright is not installed')
 def test_pyright():
-    # The importable package source lives one level up from this test directory.
-    _SOURCE_DIR = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         ['pyright', str(_SOURCE_DIR)],
         stdout=subprocess.PIPE,

--- a/nodl_schema/test/test_pyright.py
+++ b/nodl_schema/test/test_pyright.py
@@ -1,16 +1,19 @@
 # SPDX-FileCopyrightText: 2026 Open Source Robotics Foundation, Inc.
 # SPDX-License-Identifier: Apache-2.0
-"""Static type checking of the nodl_schema package with pyright."""
+"""Static type checking with pyright."""
 
 import subprocess
 import sys
 from pathlib import Path
 
-# The importable package source lives one level up from this test directory.
-_SOURCE_DIR = Path(__file__).resolve().parent.parent
+import pytest
+
+pytest.importorskip('pyright')
 
 
 def test_pyright():
+    # The importable package source lives one level up from this test directory.
+    _SOURCE_DIR = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         ['pyright', str(_SOURCE_DIR)],
         stdout=subprocess.PIPE,

--- a/ros2nodl/package.xml
+++ b/ros2nodl/package.xml
@@ -23,12 +23,12 @@
   <depend>ament_index_python</depend>
 
   <test_depend>python3-pytest</test_depend>
-  <test_depend>python3-pyright-pip</test_depend>
+  <test_depend condition="$ENABLE_PIP_TEST_DEPENDS == 1">python3-pyright-pip</test_depend>
   <test_depend>std_msgs</test_depend>
   <!-- Describe tests exercise generated messages and observe's MCAP fixtures. -->
   <test_depend>rcl_interfaces</test_depend>
   <test_depend>builtin_interfaces</test_depend>
-  <test_depend>mcap-ros2-support</test_depend>
+  <test_depend condition="$ENABLE_PIP_TEST_DEPENDS == 1">mcap-ros2-support</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2nodl/test/test_pyright.py
+++ b/ros2nodl/test/test_pyright.py
@@ -2,18 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """Static type checking with pyright."""
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
-pytest.importorskip('pyright')
+# The importable package source lives one level up from this test directory.
+_SOURCE_DIR = Path(__file__).resolve().parent.parent
 
 
+@pytest.mark.skipif(shutil.which('pyright') is None, reason='pyright is not installed')
 def test_pyright():
-    # The importable package source lives one level up from this test directory.
-    _SOURCE_DIR = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         ['pyright', str(_SOURCE_DIR)],
         stdout=subprocess.PIPE,

--- a/ros2nodl/test/test_pyright.py
+++ b/ros2nodl/test/test_pyright.py
@@ -6,11 +6,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-# The importable package source lives one level up from this test directory.
-_SOURCE_DIR = Path(__file__).resolve().parent.parent
+import pytest
+
+pytest.importorskip('pyright')
 
 
 def test_pyright():
+    # The importable package source lives one level up from this test directory.
+    _SOURCE_DIR = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         ['pyright', str(_SOURCE_DIR)],
         stdout=subprocess.PIPE,

--- a/test_ament_nodl/package.xml
+++ b/test_ament_nodl/package.xml
@@ -15,7 +15,7 @@
   <test_depend>ament_index_python</test_depend>
   <test_depend>nodl_schema</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>python3-pyright-pip</test_depend>
+  <test_depend condition="$ENABLE_PIP_TEST_DEPENDS == 1">python3-pyright-pip</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/test_ament_nodl/test/test_pyright.py
+++ b/test_ament_nodl/test/test_pyright.py
@@ -2,18 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """Static type checking with pyright."""
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
-pytest.importorskip('pyright')
+# The importable package source lives one level up from this test directory.
+_SOURCE_DIR = Path(__file__).resolve().parent.parent
 
 
+@pytest.mark.skipif(shutil.which('pyright') is None, reason='pyright is not installed')
 def test_pyright():
-    # The importable package source lives one level up from this test directory.
-    _SOURCE_DIR = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         ['pyright', str(_SOURCE_DIR)],
         stdout=subprocess.PIPE,

--- a/test_ament_nodl/test/test_pyright.py
+++ b/test_ament_nodl/test/test_pyright.py
@@ -6,11 +6,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-# The importable package source lives one level up from this test directory.
-_SOURCE_DIR = Path(__file__).resolve().parent.parent
+import pytest
+
+pytest.importorskip('pyright')
 
 
 def test_pyright():
+    # The importable package source lives one level up from this test directory.
+    _SOURCE_DIR = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         ['pyright', str(_SOURCE_DIR)],
         stdout=subprocess.PIPE,


### PR DESCRIPTION
Part of https://github.com/ros-tooling/nodl/issues/125

Bloom-released packages may not have `pip`-only dependencies, because it means they can't be packaged into `deb`/`rpm` packages due to the cross-package-manager dependency.

This PR disables those tests dependencies and the tests they enable by default - keeping them enabled here in repo-side CI. 

Any more meaningful changes than disabling are left for followup scoped changes:
- For `mcap-ros2-support`, we should be able to use `rosbag2_py` directly. We can "read rosbags" instead of "reading MCAPs", which is probably the more correct abstraction level here. 
- Pyright is just a code quality tool and is really not needed in the buildfarm - we could even move it into pre-commit, though it's much slower than the existing checkers.